### PR TITLE
Move pattern information to separate YAML files

### DIFF
--- a/httomo/data/hdf/loaders.py
+++ b/httomo/data/hdf/loaders.py
@@ -6,11 +6,9 @@ from mpi4py.MPI import Comm
 from numpy import asarray, deg2rad, ndarray, arange, linspace
 
 from httomo.data.hdf._utils import load
-from httomo.utils import _parse_preview, print_once, print_rank, pattern, \
-    Pattern
+from httomo.utils import _parse_preview, print_once, print_rank
 
 
-@pattern(Pattern.projection)
 def standard_tomo(name: str, in_file: Path, data_path: str, dimension: int,
                   preview: List[Dict[str, int]], pad: int, comm: Comm,
                   image_key_path: str=None,

--- a/httomo/methods_database/packages/httomo.yaml
+++ b/httomo/methods_database/packages/httomo.yaml
@@ -1,0 +1,5 @@
+data:
+  hdf:
+    loaders:
+      standard_tomo:
+        pattern: projection

--- a/httomo/methods_database/packages/httomolib.yaml
+++ b/httomo/methods_database/packages/httomolib.yaml
@@ -1,0 +1,46 @@
+misc:
+  corr:
+    remove_outlier3d_cupy:
+      pattern: all
+    median_filter3d_cupy:
+      pattern: all
+    inpainting_filter3d:
+      pattern: all
+  segm:
+    binary_thresholding:
+      pattern: all
+  images:
+    save_to_images:
+      pattern: all
+prep:
+  normalize:
+    normalize_cupy:
+      pattern: projection
+    normalize_raw_cuda:
+      pattern: projection
+  alignment:
+    distortion_correction_proj_cupy:
+      pattern: projection
+  phase:
+    fresnel_filter:
+      pattern: projection
+    paganin_filter:
+      pattern: projection
+    retrieve_phase:
+      pattern: projection
+  stripe:
+    remove_stripe_based_sorting:
+      pattern: sinogram
+    remove_stripe_ti:
+      pattern: sinogram
+recon:
+  rotation:
+    find_center_vo_cupy:
+      pattern: sinogram
+    find_center_360:
+      pattern: sinogram
+  algorithm:
+    reconstruct_tomobar:
+      pattern: sinogram
+    reconstruct_tomopy:
+      pattern: sinogram

--- a/httomo/methods_database/packages/tomopy.yaml
+++ b/httomo/methods_database/packages/tomopy.yaml
@@ -1,0 +1,20 @@
+prep:
+  phase:
+    retrieve_phase:
+      pattern: projection
+  normalize:
+    minus_log:
+      pattern: projection
+    normalize:
+      pattern: projection
+recon:
+  algorithm:
+    recon:
+      pattern: sinogram
+  rotation:
+    find_center_vo:
+      pattern: sinogram
+misc:
+  corr:
+    median_filter:
+      pattern: all

--- a/httomo/methods_database/query.py
+++ b/httomo/methods_database/query.py
@@ -1,14 +1,13 @@
 import yaml
 from pathlib import Path
-from typing import Dict
 
 
 YAML_DIR = Path(__file__).parent / 'packages/'
 
 
-def get_method_info(module_path: str, method_name: str) -> Dict:
-    """Get the information about the given method that is stored in the relevant
-    YAML file in `httomo/methods_database/packages/`
+def get_method_info(module_path: str, method_name: str, attr: str):
+    """Get the information about the given method associated with `attr` that
+    is stored in the relevant YAML file in `httomo/methods_database/packages/`
 
     Parameters
     ----------
@@ -19,11 +18,15 @@ def get_method_info(module_path: str, method_name: str) -> Dict:
     method_name : str
         The name of the method function.
 
+    attr : str
+        The name of the piece of information about the method being requested
+        (for example, "pattern").
+
     Returns
     -------
-    Dict
-        A dict containing all the relevant information about the method that the
-        httomo frameworks needs.
+    TODO: Needs a "generic" type to represent anything that could be stored in
+    the YAML files in the methods database?
+        The requested piece of information about the method.
     """
     method_path = f"{module_path}.{method_name}"
     split_method_path = method_path.split('.')
@@ -39,4 +42,4 @@ def get_method_info(module_path: str, method_name: str) -> Dict:
         for key in split_method_path[1:]:
             info = info[key]
 
-    return info
+    return info[attr]

--- a/httomo/methods_database/query.py
+++ b/httomo/methods_database/query.py
@@ -1,0 +1,42 @@
+import yaml
+from pathlib import Path
+from typing import Dict
+
+
+YAML_DIR = Path(__file__).parent / 'packages/'
+
+
+def get_method_info(module_path: str, method_name: str) -> Dict:
+    """Get the information about the given method that is stored in the relevant
+    YAML file in `httomo/methods_database/packages/`
+
+    Parameters
+    ----------
+    module_path : str
+        The full module path of the method, including the top-level package
+        name. Ie, `httomolib.misc.images.save_to_images`.
+
+    method_name : str
+        The name of the method function.
+
+    Returns
+    -------
+    Dict
+        A dict containing all the relevant information about the method that the
+        httomo frameworks needs.
+    """
+    method_path = f"{module_path}.{method_name}"
+    split_method_path = method_path.split('.')
+    package_name = split_method_path[0]
+    yaml_info_path = Path(YAML_DIR, f"{package_name}.yaml")
+
+    if not yaml_info_path.exists():
+        err_str = f"The YAML file {yaml_info_path} doesn't exist."
+        raise ValueError(err_str)
+
+    with open(yaml_info_path, 'r') as f:
+        info = yaml.safe_load(f)
+        for key in split_method_path[1:]:
+            info = info[key]
+
+    return info

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -746,8 +746,7 @@ def _assign_pattern_to_method(func: Callable, module_path: str,
         The function object with a `.pattern` attribute it corresponding to the
         pattern that the method requires its input data to have.
     """
-    method_info = get_method_info(module_path, method_name)
-    pattern_str = method_info['pattern']
+    pattern_str = get_method_info(module_path, method_name, 'pattern')
     if pattern_str == 'projection':
         pattern = Pattern.projection
     elif pattern_str == 'sinogram':

--- a/httomo/utils.py
+++ b/httomo/utils.py
@@ -141,37 +141,3 @@ def _get_slicing_dim(pattern: Pattern) -> int:
     else:
         err_str = f"An unknown pattern has been encountered {pattern}"
         raise ValueError(err_str)
-
-
-def pattern(pattern: Pattern) -> Callable:
-    """Decorator factory function for creating a decorator that takes a single
-    argument, the `pattern` to associate with the decorated function.
-
-    Parameters
-    ----------
-    pattern : Pattern
-        The `pattern` to associate with the given method function's data.
-
-    Returns
-    -------
-    Callable
-        The decorated method function with the `pattern` attribute set
-        accordingly.
-    """
-    def decorate(fn: Callable) -> Callable:
-        """Decorator for method functions to specify the `pattern` that the
-        method function expects for its input data.
-
-        Parameters
-        ----------
-        fn : Callable
-            The method function to set/mark the `pattern`.
-
-        Returns
-        -------
-        Callable
-            The decorated function with the `pattern` attribute set accordingly.
-        """
-        fn.pattern = pattern
-        return fn
-    return decorate

--- a/wrappers/httomolib/misc.py
+++ b/wrappers/httomolib/misc.py
@@ -3,11 +3,9 @@ import numpy as np
 import cupy as cp
 from mpi4py.MPI import Comm
 
-from httomo.utils import pattern, Pattern
 from httomolib import misc
 
 
-@pattern(Pattern.all)
 def images(params: Dict, method_name: str, out_dir: str, comm: Comm, data: np.ndarray) -> np.ndarray:
     """Wrapper for httomolib.misc.images module.
 
@@ -40,7 +38,6 @@ def images(params: Dict, method_name: str, out_dir: str, comm: Comm, data: np.nd
     return data
 
 
-@pattern(Pattern.all)
 def corr(params: Dict, method_name: str, data: np.ndarray, gpu_id: int) -> np.ndarray:
     """Wrapper for httomolib.misc.corr module.
 

--- a/wrappers/httomolib/prep.py
+++ b/wrappers/httomolib/prep.py
@@ -5,11 +5,9 @@ from numpy import ndarray
 import cupy as cp
 
 
-from httomo.utils import pattern, Pattern
 from httomolib import prep
 
 
-@pattern(Pattern.projection)
 def normalize(params: Dict, method_name: str, data: ndarray, flats: ndarray,
               darks: ndarray, gpu_id: int) -> ndarray:
     """Wrapper for httomolib.prep.normalize module.
@@ -50,7 +48,7 @@ def normalize(params: Dict, method_name: str, data: ndarray, flats: ndarray,
     data = getattr(module, method_name)(cp.asarray(data), cp.asarray(flats), cp.asarray(darks), **params)
     return cp.asnumpy(data)
 
-@pattern(Pattern.sinogram)
+
 def stripe(params: Dict, method_name: str, data: ndarray, gpu_id: int) -> ndarray:
     """Wrapper for httomolib.prep.stripe module.
 
@@ -87,7 +85,6 @@ def stripe(params: Dict, method_name: str, data: ndarray, gpu_id: int) -> ndarra
     return cp.asnumpy(data)
 
 
-@pattern(Pattern.projection)
 def phase(params: Dict, method_name: str, data: ndarray, gpu_id: int) -> ndarray:
     """Wrapper for httomolib.prep.phase module.
 

--- a/wrappers/httomolib/recon.py
+++ b/wrappers/httomolib/recon.py
@@ -4,16 +4,12 @@ from inspect import signature
 import numpy as np
 import cupy as cp
 from cupy import ndarray
-
-from httomo.utils import print_once
-
 from mpi4py.MPI import Comm
 
-from httomo.utils import pattern, Pattern
+from httomo.utils import print_once
 from httomolib import recon
 
 
-@pattern(Pattern.sinogram)
 def algorithm(params: Dict,
               method_name: str, 
               data: np.ndarray,
@@ -65,7 +61,6 @@ def algorithm(params: Dict,
         return data   
 
 
-@pattern(Pattern.sinogram)
 def rotation(params: Dict, method_name:str, comm: Comm, data: np.ndarray, gpu_id: int) -> float:
     """Wrapper for the httomolib.recon.rotation module.
 

--- a/wrappers/tomopy/misc.py
+++ b/wrappers/tomopy/misc.py
@@ -3,10 +3,7 @@ from typing import Dict
 from numpy import ndarray
 from tomopy import misc
 
-from httomo.utils import pattern, Pattern
 
-
-@pattern(Pattern.all)
 def corr(params: Dict, method_name: str, data: ndarray) -> ndarray:
     """Wrapper for tomopy.misc.corr module.
 

--- a/wrappers/tomopy/prep.py
+++ b/wrappers/tomopy/prep.py
@@ -4,9 +4,7 @@ from inspect import signature
 from numpy import ndarray
 from tomopy import prep
 
-from httomo.utils import pattern, Pattern
 
-@pattern(Pattern.sinogram)
 def stripe(params: Dict, method_name: str, data: ndarray) -> ndarray:
     """Wrapper for tomopy.prep.stripe module.
 
@@ -29,7 +27,7 @@ def stripe(params: Dict, method_name: str, data: ndarray) -> ndarray:
     data = getattr(module, method_name)(data, **params)
     return data
 
-@pattern(Pattern.projection)
+
 def normalize(params: Dict, method_name: str, data: ndarray, flats: ndarray,
               darks: ndarray) -> ndarray:
     """Wrapper for tomopy.prep.normalize module.
@@ -65,7 +63,7 @@ def normalize(params: Dict, method_name: str, data: ndarray, flats: ndarray,
         data = getattr(module, method_name)(data, **params)
     return data
 
-@pattern(Pattern.projection)
+
 def phase(params: Dict, method_name: str, data: ndarray) -> ndarray:
     """Wrapper for tomopy.prep.phase module.
 

--- a/wrappers/tomopy/recon.py
+++ b/wrappers/tomopy/recon.py
@@ -8,9 +8,7 @@ from mpi4py.MPI import Comm
 from importlib import import_module
 recon = import_module('tomopy.recon')
 
-from httomo.utils import pattern, Pattern
 
-@pattern(Pattern.sinogram)
 def algorithm(params: Dict, method_name: str, data: ndarray,
               angles_radians: ndarray) -> ndarray:
     """Wrapper for tomopy.recon.algorithm module.
@@ -39,7 +37,7 @@ def algorithm(params: Dict, method_name: str, data: ndarray,
         **params
     )
 
-@pattern(Pattern.sinogram)
+
 def rotation(params: Dict, method_name:str, comm: Comm, data: ndarray) -> float:
     """Wrapper for the tomopy.recon.rotation module.
 


### PR DESCRIPTION
This PR is intended to address #61.

The main change is to replace the `@pattern` decorator (which was used on method functions to associate patterns to the function objects), with storing pattern information in separate YAML files and fetching this information in the runner.