### PR TITLE
Adds timing + fixes GPU selection

### DIFF
--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -2,6 +2,7 @@ import multiprocessing
 from datetime import datetime
 from os import mkdir
 from pathlib import Path
+import time
 from typing import List, Dict, Optional, Tuple, Union
 from collections.abc import Callable
 from inspect import signature
@@ -119,8 +120,10 @@ def run_tasks(
         package = module_path.split(".")[0]
         method_name = params.pop("method_name")
         task_no_str = f"Running task {idx+1}"
+        task_end_str = task_no_str.replace("Running", "Finished")
         pattern_str = f"(pattern={func.pattern.name})"
         print_once(f"{task_no_str} {pattern_str}: {method_name} ({package})...", comm)
+        start = time.perf_counter_ns()
         if is_loader:
             params.update(loader_extra_params)
 
@@ -295,6 +298,9 @@ def run_tasks(
                     comm,
                     out_dir=out_dir,
                 )
+        stop = time.perf_counter_ns()
+        print_once(f"{task_end_str} {pattern_str}: {method_name} ({package}): Took {float(stop-start)*1e-6:.2f}ms", comm)
+        
 
     # Print the number of reslice operations peformed in the pipeline
     reslice_summary_str = f"Total number of reslices: {reslice_counter}"

--- a/httomo/wrappers_class.py
+++ b/httomo/wrappers_class.py
@@ -57,11 +57,11 @@ class BaseWrapper:
             params["gpu_id"] = self.gpu_id
 
         if gpu_enabled:
+            xp.cuda.Device(self.gpu_id).use()
             if self.cupyrun:
                 # the method accepts CuPy arrays for the GPU processing
-                with xp.cuda.Device(self.gpu_id):
-                    # move the data to a particular device
-                    data = xp.asarray(data)
+                # move the data to the current device
+                data = xp.asarray(data)
             else:
                 # the method doesn't accept CuPy arrays
                 data = xp.asnumpy(data)
@@ -96,13 +96,13 @@ class BaseWrapper:
             xp.ndarray: a numpy or cupy array of the normalised data.
         """
         if gpu_enabled:
+            xp.cuda.Device(self.gpu_id).use()
             if self.cupyrun:
                 # the method accepts CuPy arrays for the GPU processing
-                with xp.cuda.Device(self.gpu_id):
-                    # move the data to a particular device
-                    data = xp.asarray(data)
-                    flats = xp.asarray(flats)
-                    darks = xp.asarray(darks)
+                # move the data to the current device
+                data = xp.asarray(data)
+                flats = xp.asarray(flats)
+                darks = xp.asarray(darks)
             else:
                 # the method doesn't accept CuPy arrays
                 data = xp.asnumpy(data)
@@ -141,11 +141,11 @@ class BaseWrapper:
             params["gpu_id"] = self.gpu_id
 
         if gpu_enabled:
+            xp.cuda.Device(self.gpu_id).use()
             if self.cupyrun:
                 # the method accepts CuPy arrays for the GPU processing
-                with xp.cuda.Device(self.gpu_id):
-                    # move the data to a particular device
-                    data = xp.asarray(data)
+                # move the data to the current device
+                data = xp.asarray(data)
             else:
                 # the method doesn't accept CuPy arrays
                 data = xp.asnumpy(data)
@@ -180,11 +180,11 @@ class BaseWrapper:
         """
 
         if gpu_enabled:
+            xp.cuda.Device(self.gpu_id).use()
             if self.cupyrun:
                 # the method accepts CuPy arrays for the GPU processing
-                with xp.cuda.Device(self.gpu_id):
-                    # move the data to a particular device
-                    data = xp.asarray(data)
+                # move the data to the current device
+                data = xp.asarray(data)
             else:
                 # the method doesn't accept CuPy arrays
                 data = xp.asnumpy(data)


### PR DESCRIPTION
This adds a timing output for the execution tasks and fixes an issue with selecting the right GPU. The `with` statement that was there before seems to reset the selected GPU to 0 after, so had to revert to the `use()` method of the device.