### PR TITLE
Fix MPI size limitation for large reslice operations

### DIFF
--- a/httomo/data/hdf/_utils/reslice.py
+++ b/httomo/data/hdf/_utils/reslice.py
@@ -36,7 +36,7 @@ def reslice(
     print_once(f"<-------Reslicing/rechunking the data-------->", comm, colour=Colour.BLUE)
 
     # No need to reclice anything if there is only one process
-    if comm.size == 1:
+    if mpiutil.size == 1:
         print("Reslicing not necessary, as there is only one process")
         return data, next_slice_dim
     
@@ -45,7 +45,7 @@ def reslice(
     data_shape = chunk.get_data_shape(data, current_slice_dim - 1)
 
     # build a list of what each process has to scatter to others
-    nprocs = comm.size
+    nprocs = mpiutil.size
     length = data_shape[next_slice_dim - 1]
     split_indices = [round((length / nprocs) * r) for r in range(1, nprocs)]
     to_scatter = numpy.split(data, split_indices, axis=next_slice_dim - 1)

--- a/httomo/data/mpiutil.py
+++ b/httomo/data/mpiutil.py
@@ -1,0 +1,135 @@
+from typing import List
+import numpy as np
+
+try:
+    from mpi4py import MPI
+
+    enabled = MPI.COMM_WORLD.size > 1
+except ImportError:
+    enabled = False
+
+__all__ = ["enabled", "size", "rank", "local_size", "local_rank", "alltoall"]
+
+if enabled:
+    comm = MPI.COMM_WORLD
+    size = comm.size
+    rank = comm.rank
+    local_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
+    local_size = local_comm.size
+    local_rank = local_comm.rank
+else:
+    size = 1
+    rank = 0
+    local_size = 1
+    local_rank = 0
+
+# add this here so that we can mock it in the tests
+_mpi_max_elements = 2**31
+
+
+def alltoall(arrays: List[np.ndarray]) -> List[np.ndarray]:
+    """Distributes a list of contiguous numpy arrays from each rank to every other rank.
+
+    It also handles the case where the array sizes are larger than the max allowed by MPI
+    (INT_MAX elements, i.e. 2*31), since all MPI calls use the C int data type for representing
+    sizes.
+    It fixes this with reslice in mind, so the input arrays in the list must:
+
+    - be 3-dimensional
+    - One of these dimensions must be the same lengths for all arrays across sent/received arrays
+      (reslice maps from current slice dim to next slice dim and leaves the third dimension
+       untouched)
+
+    It picks this consistently-sized dimension and creates a new contiguous MPI data type
+    of that length. Then the sizes are divided by this length, which should make it fit in all
+    practical cases. If not, MPI will raise an exception.
+
+    Parameters
+    ----------
+    arrays : List[np.ndarray]
+        List of 3D numpy arrays to be distributed. Length must be the full size of the MPI world communicator.
+
+    Returns
+    -------
+    List[np.ndarray]
+        List of the numpy arrays received. Length is the full size of the MPI world communicator.
+    """
+
+    if len(arrays) != size:
+        raise ValueError(
+            "list of arrays for MPI alltoall call must match global communicator size"
+        )
+
+    assert all(type(a) == np.ndarray for a in arrays), "All arrays must be numpy arrays"
+    assert all(
+        a.dtype == arrays[0].dtype for a in arrays
+    ), "All arrays must be of the same type"
+    assert arrays[0].dtype in [
+        np.float32,
+        np.uint16,
+    ], "Only 16bit unsigned ints or single precision floats are implemented"
+    assert all(a.ndim == 3 for a in arrays), "Only 3D arrays are supported"
+
+    # no MPI or only one process
+    if size == 1:
+        return arrays
+
+    sizes_send = [a.size for a in arrays]
+    shapes_send = [a.shape for a in arrays]
+
+    # create a single contiguous array with all the arrays flattened and stacked up, 
+    # so that we can use MPI's Alltoallv (with buffer point + offsets)
+    # Note: the returned array from concatenate appears to always be C-contiguous
+    fullinput = np.concatenate([a.reshape(a.size) for a in arrays])
+    assert fullinput.flags.c_contiguous, "C-contigous array is required"
+    dtype = MPI.FLOAT if arrays[0].dtype == np.float32 else MPI.UINT16_T
+
+    # let everyone know the shapes / sizes they are going to receive + create an output buffer
+    shapes_rec = comm.alltoall(shapes_send)
+    sizes_rec = [np.prod(sh) for sh in shapes_rec]
+    fulloutput = np.empty((np.sum(sizes_rec),), dtype=arrays[0].dtype)
+
+    if any(s >= _mpi_max_elements for s in sizes_send) or \
+       any(s >= _mpi_max_elements for s in sizes_rec):
+        
+        # find the dim which is equal in all arrays to send/receive
+        dim0s = [s[0] for s in shapes_send] + [s[0] for s in shapes_rec]
+        dim1s = [s[1] for s in shapes_send] + [s[1] for s in shapes_rec]
+        dim2s = [s[2] for s in shapes_send] + [s[2] for s in shapes_rec]
+        dim0equal = all(s == dim0s[0] for s in dim0s)
+        dim1equal = all(s == dim1s[1] for s in dim1s)
+        dim2equal = all(s == dim2s[2] for s in dim2s)
+        assert (
+            dim0equal or dim1equal or dim2equal
+        ), "At least one dimension of the input arrays must be of same size"
+
+        # create a new contiguous MPI datatype by repeating the input type by this common length
+        factor = (
+            arrays[0].shape[0]
+            if dim0equal
+            else arrays[0].shape[1]
+            if dim1equal
+            else arrays[0].shape[2]
+        )
+        dtype1 = dtype.Create_contiguous(factor).Commit()
+        # sanity check - this should always pass
+        assert all(s % factor == 0 for s in sizes_send), "Size does not divide evenly"
+        assert all(s % factor == 0 for s in sizes_rec), "Size does not divide evenly"
+        sizes_send1 = [s // factor for s in sizes_send]
+        sizes_rec1 = [s // factor for s in sizes_rec]
+
+        # now send the same data, but with the adjusted size+datatype (output is identical)
+        comm.Alltoallv(
+            (fullinput, sizes_send1, dtype1), (fulloutput, sizes_rec1, dtype1)
+        )
+    else:
+        comm.Alltoallv((fullinput, sizes_send, dtype), (fulloutput, sizes_rec, dtype))
+
+    # build list of output arrays
+    cumsizes = np.cumsum(sizes_rec)
+    cumsizes = [0, *cumsizes[:-1]]
+    ret = list()
+    for i, s in enumerate(cumsizes):
+        ret.append(fulloutput[s : s + sizes_rec[i]].reshape(shapes_rec[i]))
+
+    return ret

--- a/httomo/data/mpiutil.py
+++ b/httomo/data/mpiutil.py
@@ -78,7 +78,7 @@ def alltoall(arrays: List[np.ndarray]) -> List[np.ndarray]:
     shapes_send = [a.shape for a in arrays]
 
     # create a single contiguous array with all the arrays flattened and stacked up, 
-    # so that we can use MPI's Alltoallv (with buffer point + offsets)
+    # so that we can use MPI's Alltoallv (with buffer pointer + offsets)
     # Note: the returned array from concatenate appears to always be C-contiguous
     fullinput = np.concatenate([a.reshape(a.size) for a in arrays])
     assert fullinput.flags.c_contiguous, "C-contigous array is required"

--- a/tests/test_mpiutil.py
+++ b/tests/test_mpiutil.py
@@ -1,0 +1,47 @@
+from httomo.data import mpiutil
+import pytest
+from mpi4py import MPI
+import numpy as np
+
+
+@pytest.mark.mpi
+def test_global_ranks():
+    assert mpiutil.rank == MPI.COMM_WORLD.rank
+    assert mpiutil.size == MPI.COMM_WORLD.size
+
+
+@pytest.mark.mpi
+def test_local_ranks():
+    # build reference local rank using MPI hostname
+    comm = MPI.COMM_WORLD
+    hosts_ranks = {}
+    host = MPI.Get_processor_name()
+    rank_host = {}
+    ret = comm.gather({comm.rank: host})
+    if comm.rank == 0:
+        for d in ret:
+            rank_host.update(d)
+    for k, v in rank_host.items():
+        if v not in hosts_ranks:
+            hosts_ranks[v] = [k]
+        else:
+            hosts_ranks[v].append(k)
+
+    hosts_ranks = comm.bcast(hosts_ranks)
+    rank_local = hosts_ranks[host].index(comm.rank)
+    size_local = len(hosts_ranks[host])
+    del rank_host
+
+    assert mpiutil.local_rank == rank_local
+    assert mpiutil.local_size == size_local
+
+
+@pytest.mark.mpi
+def test_all_to_all():
+    data = [
+        np.ones((5, 5, 5), dtype=np.uint16) * mpiutil.rank for _ in range(mpiutil.size)
+    ]
+    rec = mpiutil.alltoall(data)
+
+    expected = [np.ones((5, 5, 5), dtype=np.uint16) * r for r in range(mpiutil.size)]
+    np.testing.assert_array_equal(expected, rec)

--- a/tests/test_reslice.py
+++ b/tests/test_reslice.py
@@ -1,4 +1,5 @@
 import time
+from unittest import mock
 import numpy as np
 from mpi4py import MPI
 from httomo.data.hdf._utils.chunk import get_data_shape
@@ -22,14 +23,23 @@ import pytest
 )
 @pytest.mark.parametrize(
     "full_shape",
-    [(15, 13, 9), (12, 3, 10), (1, 4, 12), (10, 1, 12), (1, 1, 4), (4, 5, 1)],
+    [
+        (15, 13, 9),
+        (12, 3, 10),
+        (1, 4, 12),
+        (10, 1, 12),
+        (1, 1, 4),
+        (4, 5, 1),
+        (13, 23, 51),
+    ],
 )
+@pytest.mark.parametrize("dtype", [np.float32, np.uint16])
 @pytest.mark.mpi
-def test_reslice( full_shape, current_slice_dim, next_slice_dim):
-    """This test checks the reclice function in all possible dimensions and 
-       reslicing parameters. It should work without MPI (in which case the
-       output data is just the same as the input data) and with MPI for any
-       number of processes.
+def test_reslice(full_shape, current_slice_dim, next_slice_dim, dtype):
+    """This test checks the reclice function in all possible dimensions and
+    reslicing parameters. It should work without MPI (in which case the
+    output data is just the same as the input data) and with MPI for any
+    number of processes.
 
        To run with MPI, run:
 
@@ -46,10 +56,12 @@ def test_reslice( full_shape, current_slice_dim, next_slice_dim):
     stop = round(full_shape[current_slice_dim - 1] / comm.size * (comm.rank + 1))
     in_shape = np.copy(full_shape)
     in_shape[current_slice_dim - 1] = stop - start
-    data = np.ones(in_shape, dtype=np.float32) * comm.rank
+    data = np.ones(in_shape, dtype=dtype) * comm.rank
 
-    # reslice 
-    newdata, _ = reslice(data, current_slice_dim, next_slice_dim, comm)
+    # reslice, artificially mocking MPI max size to check that it can handle sizes
+    # larger than max
+    with mock.patch("httomo.data.mpiutil._mpi_max_elements", 128):
+        newdata, _ = reslice(data, current_slice_dim, next_slice_dim, comm)
 
     # check expected dimensions
     start = round((full_shape[next_slice_dim - 1] / comm.size) * comm.rank)
@@ -59,7 +71,7 @@ def test_reslice( full_shape, current_slice_dim, next_slice_dim):
     np.testing.assert_array_equal(newdata.shape, expected_dims)
 
     # check expected data
-    expected = np.ones(expected_dims, dtype=np.float32)
+    expected = np.ones(expected_dims, dtype=dtype)
     for r in range(comm.size):
         start = round(full_shape[current_slice_dim - 1] / comm.size * r)
         stop = round(full_shape[current_slice_dim - 1] / comm.size * (r + 1))


### PR DESCRIPTION
This fixes the MPI problem with reslice operations if the chunks are larger than `INT_MAX` elements (roughly 2 billion). This is a well-known issue with MPI, as all size and offset parameters accept the C type `int`, which is 32bit on most systems. A common way to address this is to create a new custom data type that is composed of multiple elementary elements joined together, and then a smaller number of elements of this new type can be sent. Note that this does not change the data itself - it's merely a different way to tell MPI what to transfer.

Further to this, it was discovered that the default `mpi4py` way to transfer Python objects is to pickle them first, then transfer, and than unpickle. With numpy arrays that we have, we can actually work directly with the raw data buffers if we make sure they are contiguous in memory. This has been adjusted in this fix as well, using the more low-level `Alltoallv` call (note the start with a capital letter).

This functionality has been factored out into a new `mpiutil` module and tested on its own, as well as with the reslice operation. 