### PR TITLE
more consistent naming for dictionaries and functions #55

### DIFF
--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -289,6 +289,7 @@ def run_tasks(
 
                 _run_method(
                     func_wrapper,
+                    func_method,
                     idx + 1,
                     package,
                     method_name,
@@ -517,6 +518,7 @@ def _get_method_funcs(
 
 def _run_method(
     func_wrapper: Callable,
+    func_method:  Callable,
     task_no: int,
     package_name: str,
     method_name: str,
@@ -534,7 +536,9 @@ def _run_method(
     Parameters
     ----------
     func_wrapper : Callable
-        The python function that performs the method.
+        The object of wrapper function that exacutes the method from a different package.
+    func_method : Callable
+        The object of a method from different package.        
     task_no : int
         The number of the given task, starting at index 1.
     package_name : str
@@ -605,11 +609,11 @@ def _run_method(
         # Check the slice dim for the method, so then the data from the
         # different MPI processes can be gathered along the correct axis when
         # saving to an intermediate file
-        recon_algorithm = method_params.pop("algorithm", None)
+        recon_algorithm = dict_params_method.pop("algorithm", None)
         if recon_algorithm is not None:
             slice_dim = 1
         else:
-            slice_dim = _get_slicing_dim(func.pattern)
+            slice_dim = _get_slicing_dim(func_method.pattern)
 
         intermediate_dataset(
             dict_datasets_pipeline[out_dataset],

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -71,9 +71,8 @@ def run_tasks(
     # more robust way than this workaround.
     SAVERS_NO_DATA_OUT_PARAM = ["save_to_images"]
 
-    # Define dict to store arrays that are specified as datasets in the user
-    # config YAML
-    datasets = _initialise_datasets(yaml_config, SAVERS_NO_DATA_OUT_PARAM)
+    # Define dict to store arrays of the whole pipeline using provided YAML
+    dict_datasets_pipeline = _initialise_datasets(yaml_config, SAVERS_NO_DATA_OUT_PARAM)
 
     # Define list to store dataset stats for each task in the user config YAML
     glob_stats = _initialise_stats(yaml_config)
@@ -83,7 +82,7 @@ def run_tasks(
     method_funcs = _get_method_funcs(yaml_config, comm)
 
     # Define dict of params that are needed by loader functions
-    loader_extra_params = {
+    dict_loader_extra_params = {
         "in_file": in_file,
         "dimension": dimension,
         "pad": pad,
@@ -102,14 +101,13 @@ def run_tasks(
     has_reslice_warn_printed = False
 
     # Associate patterns to method function objects
-    for i, (module_path, func, func_runner, params, is_loader) in enumerate(
+    for i, (module_path, func_method, func_wrapper, dict_params_method, is_loader) in enumerate(
         method_funcs
     ):
-        func = _assign_pattern_to_method(func, module_path, params["method_name"])
-        method_funcs[i] = (module_path, func, func_runner, params, is_loader)
+        func_method = _assign_pattern_to_method(func_method, module_path, dict_params_method["method_name"])
+        method_funcs[i] = (module_path, func_method, func_wrapper, dict_params_method, is_loader)
 
-    # get a list with booleans to identify when reslicing needed (True) or not
-    # (False).
+    # get a list with booleans to identify when reslicing needed 
     patterns = [f.pattern for (_, f, _, _, _) in method_funcs]
     reslice_bool_list = _check_if_should_reslice(patterns)
 
@@ -118,14 +116,14 @@ def run_tasks(
         start_time = MPI.Wtime()
 
     # Run the methods
-    for idx, (module_path, func, func_runner, params, is_loader) in enumerate(
+    for idx, (module_path, func_method, func_wrapper, dict_params_method, is_loader) in enumerate(
         method_funcs
     ):
         package = module_path.split(".")[0]
-        method_name = params.pop("method_name")
+        method_name = dict_params_method.pop("method_name")
         task_no_str = f"Running task {idx+1}"
         task_end_str = task_no_str.replace("Running", "Finished")
-        pattern_str = f"(pattern={func.pattern.name})"
+        pattern_str = f"(pattern={func_method.pattern.name})"
         print_once(
             f"{task_no_str} {pattern_str}: {method_name}...",
             comm,
@@ -133,12 +131,12 @@ def run_tasks(
         )
         start = time.perf_counter_ns()
         if is_loader:
-            params.update(loader_extra_params)
+            dict_params_method.update(dict_loader_extra_params)
 
             # Check if a value for the `preview` parameter of the loader has
             # been provided
-            if "preview" not in params.keys():
-                params["preview"] = [None]
+            if "preview" not in dict_params_method.keys():
+                dict_params_method["preview"] = [None]
 
             (
                 data,
@@ -148,22 +146,22 @@ def run_tasks(
                 angles_total,
                 detector_y,
                 detector_x,
-            ) = _run_loader(func, params)
+            ) = _run_loader(func_method, dict_params_method)
 
-            # Update `datasets` dict with the data that has been loaded by the
+            # Update `dict_datasets_pipeline` dict with the data that has been loaded by the
             # loader
-            datasets[params["name"]] = data
-            datasets["flats"] = flats
-            datasets["darks"] = darks
+            dict_datasets_pipeline[dict_params_method["name"]] = data
+            dict_datasets_pipeline["flats"] = flats
+            dict_datasets_pipeline["darks"] = darks
 
-            # Define all params relevant to httomo that a wrapper function might
-            # need
+            # Extra params relevant to httomo that a wrapper function might need
             possible_extra_params = [
                 (["darks"], darks),
                 (["flats"], flats),
                 (["angles", "angles_radians"], angles),
                 (["comm"], comm),
                 (["out_dir"], run_out_dir),
+                (["reslice_ahead"], "False"),
             ]
         else:
             save_result = False
@@ -192,35 +190,32 @@ def run_tasks(
             # Finally, check if `save_result` param has been specified in the
             # YAML config, as it can override both default behaviour and the
             # `--save_all` flag
-            if "save_result" in params.keys():
-                save_result = params.pop("save_result")
+            if "save_result" in dict_params_method.keys():
+                save_result = dict_params_method.pop("save_result")
 
             # Check if the input dataset should be resliced before the task runs
             should_reslice = reslice_bool_list[idx]
             if should_reslice:
                 reslice_counter += 1
                 current_slice_dim = _get_slicing_dim(method_funcs[idx - 1][1].pattern)
-                next_slice_dim = _get_slicing_dim(func.pattern)
+                next_slice_dim = _get_slicing_dim(func_method.pattern)
 
-            # the GPU wrapper should be aware if the reslice is needed to convert the result to numpy
+            # the GPU wrapper should know if the reslice is needed to convert the result to numpy from cupy array
             reslice_ahead = (
                 reslice_bool_list[idx + 1]
                 if idx < len(reslice_bool_list) - 1
                 else "False"
             )
-            if idx == 1:
-                possible_extra_params.append((["reslice_ahead"], reslice_ahead))
-            else:
-                possible_extra_params[-1] = (["reslice_ahead"], reslice_ahead)
+            # reslice_ahead must be the last item in the list
+            possible_extra_params[-1] = (["reslice_ahead"], reslice_ahead) 
 
             if reslice_counter > 1 and not has_reslice_warn_printed:
                 print_once(reslice_warn_str, comm=comm, colour=Colour.RED)
                 has_reslice_warn_printed = True
 
-            # Check for any extra params unrelated to wrapped packages but related to
-            # httomo that should be added in
-            httomo_params = _check_signature_for_httomo_params(
-                func_runner, method_name, possible_extra_params
+            # extra params unrelated to wrapped packages but related to httomo added
+            dict_httomo_params = _check_signature_for_httomo_params(
+                func_wrapper, method_name, possible_extra_params
             )
 
             # Get the information describing if the method is being run only
@@ -229,12 +224,12 @@ def run_tasks(
             # Make the input and output datasets always be lists just to be
             # generic, and further down loop through all the datasets that the
             # method should be applied to
-            if "data_in" in params.keys() and "data_out" in params.keys():
-                data_in = [params.pop("data_in")]
-                data_out = [params.pop("data_out")]
-            elif "data_in_multi" in params.keys() and "data_out_multi" in params.keys():
-                data_in = params.pop("data_in_multi")
-                data_out = params.pop("data_out_multi")
+            if "data_in" in dict_params_method.keys() and "data_out" in dict_params_method.keys():
+                data_in = [dict_params_method.pop("data_in")]
+                data_out = [dict_params_method.pop("data_out")]
+            elif "data_in_multi" in dict_params_method.keys() and "data_out_multi" in dict_params_method.keys():
+                data_in = dict_params_method.pop("data_in_multi")
+                data_out = dict_params_method.pop("data_out_multi")
             else:
                 # TODO: This error reporting is possibly better handled by
                 # schema validation of the user config YAML
@@ -242,26 +237,26 @@ def run_tasks(
                     err_str = "Invalid in/out dataset parameters"
                     raise ValueError(err_str)
                 else:
-                    data_in = [params.pop("data_in")]
+                    data_in = [dict_params_method.pop("data_in")]
                     data_out = [None]
 
             # Check if the method function's params require any datasets stored
-            # in the `datasets` dict
-            dataset_params = _check_method_params_for_datasets(params, datasets)
+            # in the `dict_datasets_pipeline` dict
+            dataset_params = _check_method_params_for_datasets(dict_params_method, dict_datasets_pipeline)
             # Update the relevant parameter values according to the required
             # datasets
-            params.update(dataset_params)
+            dict_params_method.update(dataset_params)
 
             # check if the module needs the ncore parameter and add it
-            if "ncore" in signature(func).parameters:
-                params.update({"ncore": ncore})
+            if "ncore" in signature(func_method).parameters:
+                dict_params_method.update({"ncore": ncore})
             # check if the module needs the gpu_id parameter and flag it to add in the wrapper
-            gpu_id_par = "gpu_id" in signature(func).parameters
+            gpu_id_par = "gpu_id" in signature(func_method).parameters
             if gpu_id_par:
-                params.update({"gpu_id": gpu_id_par})
+                dict_params_method.update({"gpu_id": gpu_id_par})
 
             # Check if method type signature requires global statistics
-            req_glob_stats = "glob_stats" in signature(func_runner).parameters
+            req_glob_stats = "glob_stats" in signature(func_wrapper).parameters
 
             for i, in_dataset in enumerate(data_in):
                 if save_result:
@@ -272,36 +267,36 @@ def run_tasks(
                 if should_reslice:
                     if reslice_dir is None:
                         resliced_data, _ = reslice(
-                            datasets[in_dataset],
+                            dict_datasets_pipeline[in_dataset],
                             current_slice_dim,
                             next_slice_dim,
                             comm,
                         )
                     else:
                         resliced_data, _ = reslice_filebased(
-                            datasets[in_dataset],
+                            dict_datasets_pipeline[in_dataset],
                             current_slice_dim,
                             next_slice_dim,
                             comm,
                             reslice_dir,
                         )
-                    datasets[in_dataset] = resliced_data
+                    dict_datasets_pipeline[in_dataset] = resliced_data
 
                 if req_glob_stats is True:
-                    stats = _fetch_glob_stats(datasets[in_dataset], comm)
+                    stats = _fetch_glob_stats(dict_datasets_pipeline[in_dataset], comm)
                     glob_stats[idx][in_dataset] = stats
-                    params.update({"glob_stats": stats})
+                    dict_params_method.update({"glob_stats": stats})
 
                 _run_method(
-                    func_runner,
+                    func_wrapper,
                     idx + 1,
                     package,
                     method_name,
                     in_dataset,
                     data_out[i],
-                    datasets,
-                    params,
-                    httomo_params,
+                    dict_datasets_pipeline,
+                    dict_params_method,
+                    dict_httomo_params,
                     SAVERS_NO_DATA_OUT_PARAM,
                     comm,
                     out_dir=out_dir,
@@ -521,15 +516,15 @@ def _get_method_funcs(
 
 
 def _run_method(
-    func_runner: Callable,
+    func_wrapper: Callable,
     task_no: int,
     package_name: str,
     method_name: str,
     in_dataset: str,
     out_dataset: Union[str, List[str]],
-    datasets: Dict[str, ndarray],
-    method_params: Dict,
-    httomo_params: Dict,
+    dict_datasets_pipeline: Dict[str, ndarray],
+    dict_params_method: Dict,
+    dict_httomo_params: Dict,
     savers_no_data_out_param: List[str],
     comm: MPI.Comm,
     out_dir: str = None,
@@ -538,23 +533,23 @@ def _run_method(
 
     Parameters
     ----------
-    func_runner : Callable
+    func_wrapper : Callable
         The python function that performs the method.
     task_no : int
         The number of the given task, starting at index 1.
     package_name : str
-        The package that the method function `func` comes from.
+        The package that the method function `func_method` comes from.
     method_name : str
         The name of the method to apply.
     in_dataset : str
         The name of the input dataset.
     out_dataset : Union[str, List[str]]
         The name(s) of the output dataset(s).
-    datasets : Dict[str, ndarray]
+    dict_datasets_pipeline : Dict[str, ndarray]
         A dict containing all available datasets in the given pipeline.
-    method_params : Dict
+    dict_params_method : Dict
         A dict of parameters for the method.
-    httomo_params : Dict, optional
+    dict_httomo_params : Dict, optional
         A dict of parameters related to HTTomo.
     savers_no_data_out_param : List[str]
         A list of savers which have neither `data_out` nor `data_out_multi` as
@@ -574,25 +569,25 @@ def _run_method(
     # parameters based on the parameter name for the method's python
     # function
     if package_name in ["httomolib", "tomopy"]:
-        httomo_params["data"] = datasets[in_dataset]
+        dict_httomo_params["data"] = dict_datasets_pipeline[in_dataset]
 
     if method_name in savers_no_data_out_param:
-        _run_method_wrapper(func_runner, method_name, method_params, httomo_params)
+        _run_method_wrapper(func_wrapper, method_name, dict_params_method, dict_httomo_params)
         # Nothing more to do with output data if the saver has a special
         # kind of output
         return
     else:
         res = _run_method_wrapper(
-            func_runner, method_name, method_params, httomo_params
+            func_wrapper, method_name, dict_params_method, dict_httomo_params
         )
 
     # Store the output(s) of the method in the appropriate dataset in the
-    # `datasets` dict
+    # `dict_datasets_pipeline` dict
     if type(res) in [list, tuple]:
         for val, dataset in zip(res, out_dataset):
-            datasets[dataset] = val
+            dict_datasets_pipeline[dataset] = val
     else:
-        datasets[out_dataset] = res
+        dict_datasets_pipeline[out_dataset] = res
 
     # TODO: The dataset saving functionality only supports 3D data
     # currently, so check that the dimension of the data is 3 before
@@ -604,31 +599,31 @@ def _run_method(
     # TODO: For now, in this case, assume that none of the results need to be
     # saved, and instead will purely be used as inputs to other methods.
     if not isinstance(out_dataset, list):
-        is_3d = len(datasets[out_dataset].shape) == 3
+        is_3d = len(dict_datasets_pipeline[out_dataset].shape) == 3
     # Save the result if necessary
     if out_dir is not None and is_3d:
         intermediate_dataset(
-            datasets[out_dataset],
+            dict_datasets_pipeline[out_dataset],
             out_dir,
             comm,
             task_no,
             package_name,
             method_name,
             out_dataset,
-            recon_algorithm=method_params.pop("algorithm", None),
+            recon_algorithm=dict_params_method.pop("algorithm", None),
         )
 
 
 def _run_loader(
-    func: Callable, params: Dict
+    func_method: Callable, dict_params_method: Dict
 ) -> Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, int, int, int]:
     """Run a loader function in the processing pipeline.
 
     Parameters
     ----------
-    func : Callable
+    func_method : Callable
         The python function that performs the loading.
-    params : Dict
+    dict_params_method : Dict
         A dict of parameters for the loader.
 
     Returns
@@ -636,23 +631,23 @@ def _run_loader(
     Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, int, int, int]
         A tuple of 8 values that all loader functions return.
     """
-    return func(**params)
+    return func_method(**dict_params_method)
 
 
 def _run_method_wrapper(
-    func_runner: Callable, method_name: str, method_params: Dict, httomo_params: Dict
+    func_wrapper: Callable, method_name: str, dict_params_method: Dict, dict_httomo_params: Dict
 ) -> ndarray:
     """Run a wrapper method function (httomolib/tomopy) in the processing pipeline.
 
     Parameters
     ----------
-    func_runner : Callable
-        The python function that performs the method.
+    func_wrapper : Callable
+        The wrapper function of the wrapper class that executes the method.
     method_name : str
         The name of the method to apply.
-    method_params : Dict
+    dict_params_method : Dict
         A dict of parameters for the tomopy method.
-    httomo_params : Dict
+    dict_httomo_params : Dict
         A dict of parameters related to httomo.
 
     Returns
@@ -660,22 +655,22 @@ def _run_method_wrapper(
     ndarray
         An array containing the result of the method function.
     """
-    return func_runner(method_name, method_params, **httomo_params)
+    return func_wrapper(method_name, dict_params_method, **dict_httomo_params)
 
 
 def _check_signature_for_httomo_params(
-    func_runner: Callable, method_name: str, params: List[Tuple[List[str], object]]
+    func_wrapper: Callable, method_name: str, possible_extra_params: List[Tuple[List[str], object]]
 ) -> Dict:
     """Check if the given method requires any parameters related to HTTomo.
 
     Parameters
     ----------
-    func_runner : Callable
-        Function whose type signature is to be inspected
+    func_wrapper : Callable
+        Function of a wrapper whose type signature is to be inspected
     method_name : str
         The name of the method to apply.
 
-    params : List[Tuple[List[str], object]]
+    possible_extra_params : List[Tuple[List[str], object]]
         Each tuples contains a parameter name and the associated value that
         should be added if a method requires that parameter (note: multiple
         parameter names can be given in case the parameter isn't consistently
@@ -688,8 +683,8 @@ def _check_signature_for_httomo_params(
         method function
     """
     extra_params = {}
-    sig_params = signature(func_runner).parameters
-    for names, val in params:
+    sig_params = signature(func_wrapper).parameters
+    for names, val in possible_extra_params:
         for name in names:
             if name in sig_params:
                 extra_params[name] = val
@@ -697,14 +692,14 @@ def _check_signature_for_httomo_params(
 
 
 def _check_method_params_for_datasets(
-    params: Dict, datasets: Dict[str, ndarray]
+    dict_params_method: Dict, datasets: Dict[str, ndarray]
 ) -> Dict:
     """Check a given method function's parameter values to see if any of them
     are a dataset.
 
     Parameters
     ----------
-    params : Dict
+    dict_params_method : Dict
         The dict of param names and their values for a given method function.
 
     datasets: Dict[str, ndarray]
@@ -719,7 +714,7 @@ def _check_method_params_for_datasets(
         method function requires.
     """
     dataset_params = {}
-    for name, val in params.items():
+    for name, val in dict_params_method.items():
         # If the value of this parameter is a dataset, then replace the
         # parameter value with the dataset value
         if val in datasets:
@@ -728,7 +723,7 @@ def _check_method_params_for_datasets(
 
 
 def _set_method_data_param(
-    func: Callable, dataset_name: str, datasets: Dict[str, ndarray]
+    func_method: Callable, dataset_name: str, datasets: Dict[str, ndarray]
 ) -> Dict[str, ndarray]:
     """Set a key in the param dict whose value is the array associated with the
     input dataset name given in the YAML config. The name of this key must be
@@ -754,7 +749,7 @@ def _set_method_data_param(
 
     Parameters
     ----------
-    func : Callable
+    func_method : Callable
         The method function whose data parameters will be inspected.
     dataset_name : str
         The name of the input dataset name from the user config YAML.
@@ -767,7 +762,7 @@ def _set_method_data_param(
         A dict containing the input data parameter key and value needed for the
         given method function.
     """
-    sig_params = list(signature(func).parameters.keys())
+    sig_params = list(signature(func_method).parameters.keys())
     # For httomo functions, the input data paramater will always be the first
     # parameter
     data_param = sig_params[0]
@@ -838,7 +833,7 @@ def _check_if_should_reslice(patterns: List[Pattern]) -> List[bool]:
 
 
 def _assign_pattern_to_method(
-    func: Callable, module_path: str, method_name: str
+    func_method: Callable, module_path: str, method_name: str
 ) -> Callable:
     """Fetch the pattern information from the methods database in
     `httomo/methods_database/packages` for the given method and associate that
@@ -846,7 +841,7 @@ def _assign_pattern_to_method(
 
     Parameters
     ----------
-    func : Callable
+    func_method : Callable
         The method function whose pattern information will be fetched.
 
     module_path : str
@@ -875,5 +870,5 @@ def _assign_pattern_to_method(
         )
         raise ValueError(err_str)
 
-    func.pattern = pattern
-    return func
+    func_method.pattern = pattern
+    return func_method

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -101,13 +101,25 @@ def run_tasks(
     has_reslice_warn_printed = False
 
     # Associate patterns to method function objects
-    for i, (module_path, func_method, func_wrapper, dict_params_method, is_loader) in enumerate(
-        method_funcs
-    ):
-        func_method = _assign_pattern_to_method(func_method, module_path, dict_params_method["method_name"])
-        method_funcs[i] = (module_path, func_method, func_wrapper, dict_params_method, is_loader)
+    for i, (
+        module_path,
+        func_method,
+        func_wrapper,
+        dict_params_method,
+        is_loader,
+    ) in enumerate(method_funcs):
+        func_method = _assign_pattern_to_method(
+            func_method, module_path, dict_params_method["method_name"]
+        )
+        method_funcs[i] = (
+            module_path,
+            func_method,
+            func_wrapper,
+            dict_params_method,
+            is_loader,
+        )
 
-    # get a list with booleans to identify when reslicing needed 
+    # get a list with booleans to identify when reslicing needed
     patterns = [f.pattern for (_, f, _, _, _) in method_funcs]
     reslice_bool_list = _check_if_should_reslice(patterns)
 
@@ -116,9 +128,13 @@ def run_tasks(
         start_time = MPI.Wtime()
 
     # Run the methods
-    for idx, (module_path, func_method, func_wrapper, dict_params_method, is_loader) in enumerate(
-        method_funcs
-    ):
+    for idx, (
+        module_path,
+        func_method,
+        func_wrapper,
+        dict_params_method,
+        is_loader,
+    ) in enumerate(method_funcs):
         package = module_path.split(".")[0]
         method_name = dict_params_method.pop("method_name")
         task_no_str = f"Running task {idx+1}"
@@ -207,7 +223,7 @@ def run_tasks(
                 else "False"
             )
             # reslice_ahead must be the last item in the list
-            possible_extra_params[-1] = (["reslice_ahead"], reslice_ahead) 
+            possible_extra_params[-1] = (["reslice_ahead"], reslice_ahead)
 
             if reslice_counter > 1 and not has_reslice_warn_printed:
                 print_once(reslice_warn_str, comm=comm, colour=Colour.RED)
@@ -224,10 +240,16 @@ def run_tasks(
             # Make the input and output datasets always be lists just to be
             # generic, and further down loop through all the datasets that the
             # method should be applied to
-            if "data_in" in dict_params_method.keys() and "data_out" in dict_params_method.keys():
+            if (
+                "data_in" in dict_params_method.keys()
+                and "data_out" in dict_params_method.keys()
+            ):
                 data_in = [dict_params_method.pop("data_in")]
                 data_out = [dict_params_method.pop("data_out")]
-            elif "data_in_multi" in dict_params_method.keys() and "data_out_multi" in dict_params_method.keys():
+            elif (
+                "data_in_multi" in dict_params_method.keys()
+                and "data_out_multi" in dict_params_method.keys()
+            ):
                 data_in = dict_params_method.pop("data_in_multi")
                 data_out = dict_params_method.pop("data_out_multi")
             else:
@@ -242,7 +264,9 @@ def run_tasks(
 
             # Check if the method function's params require any datasets stored
             # in the `dict_datasets_pipeline` dict
-            dataset_params = _check_method_params_for_datasets(dict_params_method, dict_datasets_pipeline)
+            dataset_params = _check_method_params_for_datasets(
+                dict_params_method, dict_datasets_pipeline
+            )
             # Update the relevant parameter values according to the required
             # datasets
             dict_params_method.update(dataset_params)
@@ -518,7 +542,7 @@ def _get_method_funcs(
 
 def _run_method(
     func_wrapper: Callable,
-    func_method:  Callable,
+    func_method: Callable,
     task_no: int,
     package_name: str,
     method_name: str,
@@ -538,7 +562,7 @@ def _run_method(
     func_wrapper : Callable
         The object of wrapper function that exacutes the method from a different package.
     func_method : Callable
-        The object of a method from different package.        
+        The object of a method from different package.
     task_no : int
         The number of the given task, starting at index 1.
     package_name : str
@@ -576,7 +600,9 @@ def _run_method(
         dict_httomo_params["data"] = dict_datasets_pipeline[in_dataset]
 
     if method_name in savers_no_data_out_param:
-        _run_method_wrapper(func_wrapper, method_name, dict_params_method, dict_httomo_params)
+        _run_method_wrapper(
+            func_wrapper, method_name, dict_params_method, dict_httomo_params
+        )
         # Nothing more to do with output data if the saver has a special
         # kind of output
         return
@@ -649,7 +675,10 @@ def _run_loader(
 
 
 def _run_method_wrapper(
-    func_wrapper: Callable, method_name: str, dict_params_method: Dict, dict_httomo_params: Dict
+    func_wrapper: Callable,
+    method_name: str,
+    dict_params_method: Dict,
+    dict_httomo_params: Dict,
 ) -> ndarray:
     """Run a wrapper method function (httomolib/tomopy) in the processing pipeline.
 
@@ -673,7 +702,9 @@ def _run_method_wrapper(
 
 
 def _check_signature_for_httomo_params(
-    func_wrapper: Callable, method_name: str, possible_extra_params: List[Tuple[List[str], object]]
+    func_wrapper: Callable,
+    method_name: str,
+    possible_extra_params: List[Tuple[List[str], object]],
 ) -> Dict:
     """Check if the given method requires any parameters related to HTTomo.
 

--- a/httomo/wrappers_class.py
+++ b/httomo/wrappers_class.py
@@ -57,7 +57,11 @@ class BaseWrapper:
                 return tuple(xp.asnumpy(d) for d in args)
 
     def _execute_generic(
-        self, method_name: str, dict_params_method: Dict, data: xp.ndarray, reslice_ahead: bool
+        self,
+        method_name: str,
+        dict_params_method: Dict,
+        data: xp.ndarray,
+        reslice_ahead: bool,
     ) -> xp.ndarray:
         """The generic wrapper to execute functions for external packages.
 
@@ -110,7 +114,9 @@ class BaseWrapper:
         # check where data needs to be transfered host <-> device
         data, flats, darks = self._transfer_data(data, flats, darks)
 
-        data = getattr(self.module, method_name)(data, flats, darks, **dict_params_method)
+        data = getattr(self.module, method_name)(
+            data, flats, darks, **dict_params_method
+        )
         if reslice_ahead and gpu_enabled:
             # reslice ahead, bring data back to numpy array
             return xp.asnumpy(data)
@@ -150,7 +156,9 @@ class BaseWrapper:
         if datashape0 != len(angles_radians):
             angles_radians = angles_radians[0:datashape0]
 
-        data = getattr(self.module, method_name)(data, angles_radians, **dict_params_method)
+        data = getattr(self.module, method_name)(
+            data, angles_radians, **dict_params_method
+        )
         if reslice_ahead and gpu_enabled:
             # reslice ahead, bring data back to numpy array
             return xp.asnumpy(data)
@@ -288,7 +296,12 @@ class HttomolibWrapper(BaseWrapper):
             self.cupyrun = True
 
     def _execute_images(
-        self, method_name: str, dict_params_method: Dict, out_dir: str, comm: Comm, data: xp.ndarray
+        self,
+        method_name: str,
+        dict_params_method: Dict,
+        out_dir: str,
+        comm: Comm,
+        data: xp.ndarray,
     ) -> None:
         """httomolib wrapper for save images function.
 

--- a/httomo/wrappers_class.py
+++ b/httomo/wrappers_class.py
@@ -57,13 +57,13 @@ class BaseWrapper:
                 return tuple(xp.asnumpy(d) for d in args)
 
     def _execute_generic(
-        self, method_name: str, params: Dict, data: xp.ndarray, reslice_ahead: bool
+        self, method_name: str, dict_params_method: Dict, data: xp.ndarray, reslice_ahead: bool
     ) -> xp.ndarray:
         """The generic wrapper to execute functions for external packages.
 
         Args:
             method_name (str): The name of the method to use.
-            params (Dict): A dict containing independent of httomo params.
+            dict_params_method (Dict): A dict containing parameters of the executed method.
             data (xp.ndarray): a numpy or cupy data array.
             reslice_ahead (bool): a bool to inform the wrapper if the reslice ahead and the conversion to numpy required.
 
@@ -71,13 +71,13 @@ class BaseWrapper:
             xp.ndarray: A numpy or cupy array containing processed data.
         """
         # set the correct GPU ID if it is required
-        if "gpu_id" in params:
-            params["gpu_id"] = self.gpu_id
+        if "gpu_id" in dict_params_method:
+            dict_params_method["gpu_id"] = self.gpu_id
 
         # check if data needs to be transfered host <-> device
         data = self._transfer_data(data)
 
-        data = getattr(self.module, method_name)(data, **params)
+        data = getattr(self.module, method_name)(data, **dict_params_method)
         if reslice_ahead and gpu_enabled:
             # reslice ahead, bring data back to numpy array
             return xp.asnumpy(data)
@@ -87,7 +87,7 @@ class BaseWrapper:
     def _execute_normalize(
         self,
         method_name: str,
-        params: Dict,
+        dict_params_method: Dict,
         data: xp.ndarray,
         flats: xp.ndarray,
         darks: xp.ndarray,
@@ -97,7 +97,7 @@ class BaseWrapper:
 
         Args:
             method_name (str): The name of the method to use.
-            params (Dict): A dict containing independent of httomo params.
+            dict_params_method (Dict): A dict containing parameters of the executed method.
             data (xp.ndarray): a numpy or cupy data array.
             flats (xp.ndarray): a numpy or cupy flats array.
             darks (xp.ndarray): a numpy or darks flats array.
@@ -110,7 +110,7 @@ class BaseWrapper:
         # check where data needs to be transfered host <-> device
         data, flats, darks = self._transfer_data(data, flats, darks)
 
-        data = getattr(self.module, method_name)(data, flats, darks, **params)
+        data = getattr(self.module, method_name)(data, flats, darks, **dict_params_method)
         if reslice_ahead and gpu_enabled:
             # reslice ahead, bring data back to numpy array
             return xp.asnumpy(data)
@@ -120,7 +120,7 @@ class BaseWrapper:
     def _execute_reconstruction(
         self,
         method_name: str,
-        params: Dict,
+        dict_params_method: Dict,
         data: xp.ndarray,
         angles_radians: np.ndarray,
         reslice_ahead: bool,
@@ -129,7 +129,7 @@ class BaseWrapper:
 
         Args:
             method_name (str): The name of the method to use.
-            params (Dict): A dict containing independent of httomo params.
+            dict_params_method (Dict): A dict containing parameters of the executed method.
             data (xp.ndarray): a numpy or cupy data array.
             angles_radians (np.ndarray): a numpy array of projection angles.
             reslice_ahead (bool): a bool to inform the wrapper if the reslice ahead and the conversion to numpy required.
@@ -138,8 +138,8 @@ class BaseWrapper:
             xp.ndarray: a numpy or cupy array of the reconstructed data.
         """
         # set the correct GPU ID if it is required
-        if "gpu_id" in params:
-            params["gpu_id"] = self.gpu_id
+        if "gpu_id" in dict_params_method:
+            dict_params_method["gpu_id"] = self.gpu_id
 
         # check if data needs to be transfered host <-> device
         data = self._transfer_data(data)
@@ -150,7 +150,7 @@ class BaseWrapper:
         if datashape0 != len(angles_radians):
             angles_radians = angles_radians[0:datashape0]
 
-        data = getattr(self.module, method_name)(data, angles_radians, **params)
+        data = getattr(self.module, method_name)(data, angles_radians, **dict_params_method)
         if reslice_ahead and gpu_enabled:
             # reslice ahead, bring data back to numpy array
             return xp.asnumpy(data)
@@ -160,14 +160,14 @@ class BaseWrapper:
     def _execute_rotation(
         self,
         method_name: str,
-        params: Dict,
+        dict_params_method: Dict,
         data: xp.ndarray,
     ) -> tuple:
         """The center of rotation wrapper.
 
         Args:
             method_name (str): The name of the method to use.
-            params (Dict): A dict containing independent of httomo params.
+            dict_params_method (Dict): A dict containing parameters of the executed method.
             data (xp.ndarray): a numpy or cupy data array.
 
         Returns:
@@ -184,14 +184,14 @@ class BaseWrapper:
         overlap_position = 0
         mid_rank = int(round(self.comm.size / 2) + 0.1)
         if self.comm.rank == mid_rank:
-            if params["ind"] == "mid":
-                params["ind"] = data.shape[1] // 2  # get the middle slice
+            if dict_params_method["ind"] == "mid":
+                dict_params_method["ind"] = data.shape[1] // 2  # get the middle slice
             if method_name == "find_center_360":
                 (rot_center, overlap, side, overlap_position) = method_func(
-                    data, **params
+                    data, **dict_params_method
                 )
             else:
-                rot_center = method_func(data, **params)
+                rot_center = method_func(data, **dict_params_method)
 
         if method_name == "find_center_vo":
             rot_center = self.comm.bcast(rot_center, root=mid_rank)
@@ -288,13 +288,13 @@ class HttomolibWrapper(BaseWrapper):
             self.cupyrun = True
 
     def _execute_images(
-        self, method_name: str, params: Dict, out_dir: str, comm: Comm, data: xp.ndarray
+        self, method_name: str, dict_params_method: Dict, out_dir: str, comm: Comm, data: xp.ndarray
     ) -> None:
         """httomolib wrapper for save images function.
 
         Args:
             method_name (str): The name of the method to use.
-            params (Dict): A dict containing independent of httomo params.
+            dict_params_method (Dict): A dict containing parameters of the executed method.
             out_dir (str): The output directory.
             comm (Comm): The MPI communicator.
             data (xp.ndarray): a numpy or cupy data array.
@@ -304,10 +304,10 @@ class HttomolibWrapper(BaseWrapper):
         """
         if gpu_enabled:
             data = getattr(self.module, method_name)(
-                xp.asnumpy(data), out_dir, comm_rank=comm.rank, **params
+                xp.asnumpy(data), out_dir, comm_rank=comm.rank, **dict_params_method
             )
         else:
             data = getattr(self.module, method_name)(
-                data, out_dir, comm_rank=comm.rank, **params
+                data, out_dir, comm_rank=comm.rank, **dict_params_method
             )
         return None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -125,7 +125,7 @@ def test_diad_testing_pipeline_output(
         assert f["data"].dtype == np.float32
         assert_allclose(np.mean(f["data"]), 0.172585, atol=1e-6)
         assert_allclose(np.sum(f["data"]), 26932.186, atol=1e-6)
-    
+
     # reslicing through memory - no file
     # with h5py.File(h5_files[2], "r") as f:
     #     #: intermediate.h5


### PR DESCRIPTION
Follows discussion in #55 but actually keeping most of things as they are. 
The main changes are: 
- dictionaries have `dict` in front of them and renamed as: `dict_datasets_pipeline, dict_params_method, dict_httomo_params`. I don't think we need something more granular than this at this point. 
- Function objects renamed to  `func_method, func_wrapper`. One assciated with the actual method and one with the wrapper
- In the wrapper class there were incorrect descriptions for `params` dictionary, now fixed with the less ambiguous name: `dict_params_method`
