### PR TITLE
Add basic YAML checker

### DIFF
--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -1,0 +1,37 @@
+"""
+Module for checking the validity of yaml files.
+"""
+
+import yaml
+from httomo.yaml_utils import open_yaml_config
+
+__all__ = ['validate_yaml']
+
+
+def validate_yaml(yaml_file):
+    """
+    Check if the yaml file is properly indented, has valid mapping and tags.
+    """
+    with open(yaml_file, 'r') as file:
+        try:
+            yaml_data = open_yaml_config(yaml_file)
+        except yaml.parser.ParserError as e:
+            line = e.problem_mark.line
+            print(
+                f"Incorrect indentation in the YAML_CONFIG file at line {line}. "
+                "Please recheck the indentation of the file."
+            )
+        except yaml.scanner.ScannerError as e:
+            print(
+                f"Incorrect mapping in the YAML_CONFIG file at line {e.problem_mark.line + 1}."
+            )
+        except yaml.constructor.ConstructorError as e:
+            print(f"Invalid tag in the YAML_CONFIG file at line {e.problem_mark.line + 1}.")
+        except yaml.reader.ReaderError as e:
+            print(f"Failed to parse YAML file at line {e.problem_mark.line + 1}: {e}")
+        except yaml.YAMLError as e:
+            if hasattr(e, 'problem_mark'):
+                print(
+                    f"Error in the YAML_CONFIG file at line {e.problem_mark.line}. "
+                    "Please recheck the file."
+                )

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -18,7 +18,7 @@ def sanity_check(yaml_file):
     """
     with open(yaml_file, "r") as file:
         try:
-            yaml_data = open_yaml_config(yaml_file)
+            return open_yaml_config(yaml_file)
         except yaml.parser.ParserError as e:
             line = e.problem_mark.line
             print(
@@ -41,8 +41,6 @@ def sanity_check(yaml_file):
                     f"Error in the YAML_CONFIG file at line {e.problem_mark.line}. "
                     "Please recheck the file."
                 )
-
-    return yaml_data
 
 
 def check_one_method_per_module(yaml_file):
@@ -70,6 +68,7 @@ def check_one_method_per_module(yaml_file):
                 f" module '{next(iter(yaml_data[i]))}'. "
                 "Please recheck the yaml file."
             )
+            return False
 
     return yaml_data
 
@@ -160,5 +159,6 @@ def validate_yaml_config(yaml_file) -> bool:
                         f"Value assigned to parameter '{parameter}' in the '{modules[i]}' method"
                         f" is not correct. It should be of type {type(d2[key][parameter])}."
                     )
+                    return False
 
     return True

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -1,18 +1,22 @@
 """
 Module for checking the validity of yaml files.
 """
-
+import os
 import yaml
 from httomo.yaml_utils import open_yaml_config
 
-__all__ = ["sanity_check", "check_one_method_per_module"]
+__all__ = [
+    "check_one_method_per_module",
+    "sanity_check",
+    "validate_yaml_config",
+]
 
 
 def sanity_check(yaml_file):
     """
     Check if the yaml file is properly indented, has valid mapping and tags.
     """
-    with open(yaml_file, 'r') as file:
+    with open(yaml_file, "r") as file:
         try:
             yaml_data = open_yaml_config(yaml_file)
         except yaml.parser.ParserError as e:
@@ -26,11 +30,13 @@ def sanity_check(yaml_file):
                 f"Incorrect mapping in the YAML_CONFIG file at line {e.problem_mark.line + 1}."
             )
         except yaml.constructor.ConstructorError as e:
-            print(f"Invalid tag in the YAML_CONFIG file at line {e.problem_mark.line + 1}.")
+            print(
+                f"Invalid tag in the YAML_CONFIG file at line {e.problem_mark.line + 1}."
+            )
         except yaml.reader.ReaderError as e:
             print(f"Failed to parse YAML file at line {e.problem_mark.line + 1}: {e}")
         except yaml.YAMLError as e:
-            if hasattr(e, 'problem_mark'):
+            if hasattr(e, "problem_mark"):
                 print(
                     f"Error in the YAML_CONFIG file at line {e.problem_mark.line}. "
                     "Please recheck the file."
@@ -66,3 +72,72 @@ def check_one_method_per_module(yaml_file):
             )
 
     return yaml_data
+
+
+def validate_yaml_config(yaml_file):
+    """
+    Check that the modules, methods, and parameters in the `YAML_CONFIG` file
+    are valid, and adhere to the same structure as in each corresponding
+    module in `httomo.templates`.
+    """
+    yaml_data = check_one_method_per_module(yaml_file)
+
+    modules = [next(iter(d)) for d in yaml_data]
+    methods = [next(iter(d.values())) for d in yaml_data]
+    packages = [m.split(".")[0] for m in modules]
+
+    #: the first method is always a loader
+    #: so `testing_pipeline.yaml` should not pass.
+    if next(iter(methods[0])) != "standard_tomo":
+        print(
+            "The first method in the YAML_CONFIG file must be a loader. "
+            "Please recheck the yaml file."
+        )
+        return False
+
+    parent_dir = os.path.dirname(os.path.abspath("__file__"))
+    templates_dir = os.path.join(parent_dir, "templates")
+    assert os.path.exists(templates_dir)
+
+    _template_yaml_files = [
+        os.path.join(
+            templates_dir, packages[i], modules[i], next(iter(methods[i])) + ".yaml"
+        )
+        for i in range(len(modules))
+    ]
+
+    for i, f in enumerate(_template_yaml_files):
+        if not os.path.exists(f):
+            print(
+                f"'{modules[i] + '/' + next(iter(methods[i]))}' is not a valid"
+                 " path to a method. Please recheck the yaml file."
+            )
+            return False
+
+    _template_yaml_data_list = [
+        next(iter(d.values()))
+        for f in _template_yaml_files
+        for d in open_yaml_config(f)
+    ]
+
+    for i, _ in enumerate(modules):
+        d1 = methods[i]
+        d2 = _template_yaml_data_list[i]
+
+        for key in d1.keys():
+            for parameter in d1[key].keys():
+                assert isinstance(parameter, str)
+                if parameter not in d2[key].keys():
+                    print(
+                        f"Parameter '{parameter}' in the '{modules[i]}' method is not valid."
+                    )
+                    return False
+
+                if None in (d1[key][parameter], d2[key][parameter]):
+                    continue
+
+                if not isinstance(d1[key][parameter], type(d2[key][parameter])):
+                    print(
+                        f"Value assigned to parameter '{parameter}' in the '{modules[i]}' method"
+                        f" is not correct. It should be of type {type(d2[key][parameter])}."
+                    )

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -5,10 +5,10 @@ Module for checking the validity of yaml files.
 import yaml
 from httomo.yaml_utils import open_yaml_config
 
-__all__ = ['validate_yaml']
+__all__ = ["sanity_check", "check_one_method_per_module"]
 
 
-def validate_yaml(yaml_file):
+def sanity_check(yaml_file):
     """
     Check if the yaml file is properly indented, has valid mapping and tags.
     """
@@ -35,3 +35,34 @@ def validate_yaml(yaml_file):
                     f"Error in the YAML_CONFIG file at line {e.problem_mark.line}. "
                     "Please recheck the file."
                 )
+
+    return yaml_data
+
+
+def check_one_method_per_module(yaml_file):
+    """
+    Check that we cannot have a yaml file with more than one method
+    being called from one module. For example, we cannot have:
+
+    - tomopy.prep.normalize:
+        normalize:
+          data_in: tomo
+          data_out: tomo
+          cutoff: null
+        minus_log:
+          data_in: tomo
+          data_out: tomo
+    """
+    yaml_data = sanity_check(yaml_file)
+
+    lvalues = [value for d in yaml_data for value in d.values()]
+    for i, d in enumerate(lvalues):
+        assert isinstance(d, dict)
+        if len(d) != 1:
+            print(
+                f"More than one method is being called from the"
+                f" module '{next(iter(yaml_data[i]))}'. "
+                "Please recheck the yaml file."
+            )
+
+    return yaml_data

--- a/samples/pipeline_template_examples/testing/incorrect_method.yaml
+++ b/samples/pipeline_template_examples/testing/incorrect_method.yaml
@@ -1,0 +1,22 @@
+- httomo.data.hdf.loaders:
+    standard_tomo:
+      name: tomo
+      data_path: entry1/tomo_entry/data/data
+      image_key_path: entry1/tomo_entry/instrument/detector/image_key
+      preview:
+        - 
+        - start: 30
+          stop: 60
+        - 
+      pad: 0
+- tomopy.misc.corr:
+    median_filters:
+      data: tomo
+      data_out: tomo
+      size: tomo
+      axis: 0
+- tomopy.prep.normalize:
+    normalize:
+      data_in: tomo
+      data_out: tomo
+      cutoff: null

--- a/samples/pipeline_template_examples/testing/more_than_one_method.yaml
+++ b/samples/pipeline_template_examples/testing/more_than_one_method.yaml
@@ -3,9 +3,11 @@
       name: tomo
       data_path: entry1/tomo_entry/data/data
       image_key_path: entry1/tomo_entry/instrument/detector/image_key
-- httomolib.misc.corr:
-    remove_outlier3d:
-      data_in_multi: [tomo, flats, darks]
-      data_out_multi: [tomo, flats, darks]
-      kernel_size: 3
-      dif: 0.1
+- tomopy.prep.normalize:
+    normalize:
+      data_in: tomo
+      data_out: tomo
+      cutoff: null
+    minus_log:
+      data_in: tomo
+      data_out: tomo

--- a/samples/pipeline_template_examples/testing/wrong_indentation_pipeline.yaml
+++ b/samples/pipeline_template_examples/testing/wrong_indentation_pipeline.yaml
@@ -1,0 +1,7 @@
+- httomo.data.hdf.loaders:
+    standard_tomo:
+        name: tomo
+      data_path: /entry1/tomo_entry/data/data
+      image_key_path: /entry1/tomo_entry/instrument/detector/image_key
+      dimension: 1
+      pad: 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,16 @@ def standard_loader():
 
 
 @pytest.fixture
+def more_than_one_method():
+    return "samples/pipeline_template_examples/testing/more_than_one_method.yaml"
+
+
+@pytest.fixture
+def sample_pipelines():
+    return "samples/pipeline_template_examples/"
+
+
+@pytest.fixture
 def merge_yamls():
     def _merge_yamls(*yamls) -> None:
         """Merge multiple yaml files into one"""

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -1,0 +1,44 @@
+"""
+Some unit tests for the yaml checker
+"""
+import pytest
+from httomo.yaml_checker import (
+    check_one_method_per_module,
+    sanity_check,
+    validate_yaml_config,
+)
+
+
+def test_sanity_check(sample_pipelines):
+    wrong_indentation_pipeline = (
+        sample_pipelines + "testing/wrong_indentation_pipeline.yaml"
+    )
+    assert not sanity_check(wrong_indentation_pipeline)
+
+
+def test_one_method_per_module(more_than_one_method):
+    assert not check_one_method_per_module(more_than_one_method)
+
+
+@pytest.mark.parametrize(
+    "yaml_file, expected",
+    [
+        ("testing/testing_pipeline.yaml", False),
+        ("testing/incorrect_method.yaml", False),
+        ("02_basic_cpu_pipeline_tomo_standard.yaml", True),
+        ("04_basic_gpu_pipeline_tomo_standard.yaml", True),
+        ("multi_inputs/01_dezing_multi_inputs.yaml", True),
+        ("parameter_sweeps/02_median_filter_kernel_sweep.yaml", True),
+    ],
+    ids=[
+        "no_loader_pipeline",
+        "incorrect_method",
+        "cpu_pipeline",
+        "gpu_pipeline",
+        "multi_input_pipeline",
+        "sweep_pipeline",
+    ],
+)
+def test_validate_yaml_config(sample_pipelines, yaml_file, expected):
+    yaml_file = sample_pipelines + yaml_file
+    assert validate_yaml_config(yaml_file) == expected


### PR DESCRIPTION
Fixes #100 
- [x] basic sanity check
- [x] check that only one method is being called from each module
- [x] use `httomo.templates` to validate the `YAML_CONFIG` (i.e., check modules, functions, and parameters are valid)
- [x] check that the first method is always a loader (so `testing_pipeline.yaml` should raise an error).
- [x] (handle some exceptional cases in the task above like `!Sweep` and `data_in_multi`/`data_out_multi`).
- [x] add unit tests


