### PR TITLE
Memory chunking in httomo

### DIFF
--- a/httomo/data/hdf/_utils/load.py
+++ b/httomo/data/hdf/_utils/load.py
@@ -1,5 +1,5 @@
 import math
-from typing import Tuple, List, Dict
+from typing import Optional, Tuple, List, Dict
 
 import h5py as h5
 import numpy as np
@@ -376,9 +376,9 @@ def get_angles(file: str, path: str, comm: MPI.Comm = MPI.COMM_WORLD) -> ndarray
 def get_darks_flats_together(
     file: str,
     data_path: str = "/entry1/tomo_entry/data/data",
-    darks_path: str = None,
-    flats_path: str = None,
-    image_key_path: str = "/entry1/instrument/image_key/image_key",
+    darks_path: Optional[str] = None,
+    flats_path: Optional[str] = None,
+    image_key_path: Optional[str] = "/entry1/instrument/image_key/image_key",
     dim: int = 1,
     pad: int = 0,
     preview: str = ":,:,:",

--- a/httomo/data/hdf/loaders.py
+++ b/httomo/data/hdf/loaders.py
@@ -1,5 +1,7 @@
+from dataclasses import dataclass
+import os
 from pathlib import Path
-from typing import Tuple, List, Dict
+from typing import Any, Tuple, List, Dict, Optional
 
 from h5py import File
 from mpi4py.MPI import Comm
@@ -8,20 +10,30 @@ from numpy import asarray, deg2rad, ndarray, arange, linspace
 from httomo.data.hdf._utils import load
 from httomo.utils import _parse_preview, print_once, print_rank
 
+@dataclass
+class LoaderData:
+    data: ndarray
+    flats: ndarray
+    darks: ndarray
+    angles: ndarray
+    angles_total: int
+    detector_x: int
+    detector_y: int
+
 
 def standard_tomo(
     name: str,
-    in_file: Path,
+    in_file: os.PathLike | str,
     data_path: str,
     dimension: int,
     preview: List[Dict[str, int]],
     pad: int,
     comm: Comm,
-    image_key_path: str = None,
-    rotation_angles: Dict = {"data_path": "/entry1/tomo_entry/data/rotation_angle"},
-    darks: Dict = None,
-    flats: Dict = None,
-) -> Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, int, int, int]:
+    image_key_path: Optional[str] = None,
+    rotation_angles: Dict[str, Any] = {"data_path": "/entry1/tomo_entry/data/rotation_angle"},
+    darks: Optional[Dict] = None,
+    flats: Optional[Dict] = None,
+) -> LoaderData:
     """Loader for standard tomography data.
 
     Parameters
@@ -56,8 +68,8 @@ def standard_tomo(
 
     Returns
     -------
-    Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, int, int, int]
-        A tuple of 8 values that all loader functions return.
+    LoaderData
+        The values that all loader functions return.
     """
     with File(in_file, "r", driver="mpio", comm=comm) as file:
         dataset = file[data_path]
@@ -69,19 +81,19 @@ def standard_tomo(
     # Get indices in data which contain projections
     if image_key_path is not None:
         data_indices = load.get_data_indices(
-            in_file,
+            str(in_file),
             image_key_path=image_key_path,
             comm=comm,
         )
     else:
         # Assume that only projection data is in `in_file` (no darks/flats), so
         # the "data indices" are simply all images in `in_file`
-        data_indices = arange(shape[0])
+        data_indices = list(arange(shape[0]))
 
     # Get the angles associated to the projection data
     if "data_path" in rotation_angles.keys():
         angles_degrees = load.get_angles(
-            in_file, path=rotation_angles["data_path"], comm=comm
+            str(in_file), path=rotation_angles["data_path"], comm=comm
         )
     else:
         angles_info = rotation_angles["user_defined"]
@@ -106,23 +118,23 @@ def standard_tomo(
     )
     print_rank(f"Pad values are {pad_values}.", comm)
     data = load.load_data(
-        in_file, dim, data_path, preview=preview_str, pad=pad_values, comm=comm
+        str(in_file), dim, data_path, preview=preview_str, pad=pad_values, comm=comm
     )
 
     # Get darks and flats
     if darks is not None and flats is not None and darks["file"] != flats["file"]:
         # Get darks and flats from different datasets within different NeXuS
         # files
-        darks = load.get_darks_flats_separate(
+        darks_data = load.get_darks_flats_separate(
             darks["file"], darks["data_path"], dim=dimension, preview=preview_str
         )
-        flats = load.get_darks_flats_separate(
+        flats_data = load.get_darks_flats_separate(
             flats["file"], flats["data_path"], dim=dimension, preview=preview_str
         )
     elif darks is not None and flats is not None and darks["file"] == flats["file"]:
         # Get darks and flats from different datasets within the same NeXuS file
-        darks, flats = load.get_darks_flats_together(
-            in_file,
+        darks_data, flats_data = load.get_darks_flats_together(
+            str(in_file),
             data_path,
             darks_path=darks["data_path"],
             flats_path=flats["data_path"],
@@ -133,16 +145,14 @@ def standard_tomo(
         )
     else:
         # Get darks and flats from the same dataset within the same NeXuS file
-        darks, flats = load.get_darks_flats_together(
-            in_file,
+        darks_data, flats_data = load.get_darks_flats_together(
+            str(in_file),
             data_path,
             image_key_path=image_key_path,
             comm=comm,
             preview=preview_str,
             dim=dimension,
         )
-    darks = asarray(darks)
-    flats = asarray(flats)
 
     (angles_total, detector_y, detector_x) = data.shape
     print_rank(
@@ -151,4 +161,10 @@ def standard_tomo(
         comm,
     )
 
-    return data, flats, darks, angles, angles_total, detector_y, detector_x
+    return LoaderData(data=data, 
+                      flats=asarray(flats_data), 
+                      darks=asarray(darks_data), 
+                      angles=angles, 
+                      angles_total=angles_total, 
+                      detector_y=detector_y, 
+                      detector_x=detector_x)

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -238,7 +238,7 @@ def run_tasks(
     reslice_summary_colour = Colour.BLUE if reslice_counter <= 1 else Colour.RED
     print_once(reslice_summary_str, comm=comm, colour=reslice_summary_colour)
 
-    elapsed_time = 0
+    elapsed_time = 0.
     if comm.rank == 0:
         elapsed_time = MPI.Wtime() - start_time
         end_str = f"\n\n~~~ Pipeline finished ~~~\nTook {elapsed_time} sec to run!"
@@ -266,7 +266,7 @@ def _initialise_datasets(
         values will eventually be arrays (but initialised to None in this
         function)
     """
-    datasets = {}
+    datasets: Dict[str, None] = {}
     # Define the params related to dataset names in the given function, whether
     # it's a loader or a method function
     loader_dataset_params = ["name"]
@@ -315,7 +315,7 @@ def _initialise_datasets(
 # TODO: There's a lot of overlap with the `_initialise_datasets()` function, the
 # only difference is that this function doesn't need to inspect the output
 # datasets of a method, so perhaps the two functions can be nicely merged?
-def _initialise_stats(yaml_config: Path) -> List[Dict]:
+def _initialise_stats(yaml_config: Path) -> List[Dict[str, List]]:
     """Generate a list of dicts that will hold the stats for the datasets in all
     the methods in the pipeline.
 
@@ -330,7 +330,7 @@ def _initialise_stats(yaml_config: Path) -> List[Dict]:
         A list containing the stats of all datasets of all methods in the
         pipeline.
     """
-    stats = []
+    stats: List[Dict[str, List]] = []
     # Define the params related to dataset names in the given function, whether
     # it's a loader or a method function
     loader_dataset_param = "name"
@@ -350,7 +350,7 @@ def _initialise_stats(yaml_config: Path) -> List[Dict]:
             dataset_param = method_dataset_param
 
         # Dict to hold the stats for each dataset associated with the method
-        method_stats = {}
+        method_stats: Dict[str, List]= {}
 
         # Check if there are multiple input datasets to account for
         if type(method_conf[dataset_param]) is list:
@@ -366,7 +366,7 @@ def _initialise_stats(yaml_config: Path) -> List[Dict]:
 
 def _get_method_funcs(
     yaml_config: Path, comm: MPI.Comm
-) -> List[Tuple[str, Callable, Dict, bool]]:
+) -> List[Tuple[str, Callable, Optional[Callable], Dict, bool]]:
     """Gather all the python functions needed to run the defined processing
     pipeline.
 
@@ -378,14 +378,15 @@ def _get_method_funcs(
         MPI communicator object.
     Returns
     -------
-    List[Tuple[Callable, Dict, bool]]
+    List[Tuple[str, Callable, Optional[Callable], Dict, bool]]
         A list, each element being a tuple containing four elements:
         - a package name
         - a method function
+        - optionally a wrapper function to use (httomo loaders set this to None)
         - a dict of parameters for the method function
         - a boolean describing if it is a loader function or not
     """
-    method_funcs = []
+    method_funcs: List[Tuple[str, Callable, Optional[Callable], Dict, bool]] = []
     yaml_conf = open_yaml_config(yaml_config)
 
     for task_conf in yaml_conf:
@@ -393,31 +394,30 @@ def _get_method_funcs(
         split_module_name = module_name.split(".")
         method_name, method_conf = module_conf.popitem()
         method_conf["method_name"] = method_name
-
+        
         if split_module_name[0] == "httomo":
             # deal with httomo loaders
-            if "loaders" in module_name:
-                is_loader = True
-            else:
-                is_loader = False
+            is_loader = "loaders" in module_name
             module = import_module(module_name)
-            method_func = getattr(module, method_name)
+            method_func: Callable = getattr(module, method_name)
             method_funcs.append(
                 (module_name, method_func, None, method_conf, is_loader)
             )
-        elif (split_module_name[0] == "tomopy") or (
-            split_module_name[0] == "httomolib"
-        ):
-            if split_module_name[0] == "tomopy":
-                # initialise the TomoPy wrapper class
-                wrapper_init_module = TomoPyWrapper(
-                    split_module_name[1], split_module_name[2], method_name, comm
-                )
-            if split_module_name[0] == "httomolib":
-                # initialise the httomolib wrapper class
-                wrapper_init_module = HttomolibWrapper(
-                    split_module_name[1], split_module_name[2], method_name, comm
-                )
+        elif split_module_name[0] == "tomopy":
+            # initialise the TomoPy wrapper class
+            wrapper_init_module = TomoPyWrapper(
+                split_module_name[1], split_module_name[2], method_name, comm
+            )
+            wrapper_func: Callable = getattr(wrapper_init_module.module, method_name)
+            wrapper_method = wrapper_init_module.wrapper_method
+            method_funcs.append(
+                (module_name, wrapper_func, wrapper_method, method_conf, False)
+            )
+        elif split_module_name[0] == "httomolib":
+            # initialise the httomolib wrapper class
+            wrapper_init_module = HttomolibWrapper(
+                split_module_name[1], split_module_name[2], method_name, comm
+            )
             wrapper_func = getattr(wrapper_init_module.module, method_name)
             wrapper_method = wrapper_init_module.wrapper_method
             method_funcs.append(

--- a/httomo/wrappers_class.py
+++ b/httomo/wrappers_class.py
@@ -1,7 +1,7 @@
-from typing import Dict, Union
+from typing import Dict, Tuple, Union
 import numpy as np
 import inspect
-from inspect import signature
+from inspect import Parameter, signature
 from httomo.utils import print_once
 from httomo.data import mpiutil
 
@@ -23,13 +23,15 @@ except ImportError:
 
     print("CuPy is not installed")
 
+
 def _gpumem_cleanup():
-    """cleans up GPU memory and also the FFT plan cache
-    """
-    xp.get_default_memory_pool().free_all_blocks()
-    cache = xp.fft.config.get_plan_cache()
-    cache.clear()
-    
+    """cleans up GPU memory and also the FFT plan cache"""
+    if gpu_enabled:
+        xp.get_default_memory_pool().free_all_blocks()
+        cache = xp.fft.config.get_plan_cache()
+        cache.clear()
+
+
 class BaseWrapper:
     """A parent class for all wrappers in httomo that use external modules."""
 
@@ -37,9 +39,10 @@ class BaseWrapper:
         self, module_name: str, function_name: str, method_name: str, comm: Comm
     ):
         self.comm = comm
+        self.cupyrun = False
         if gpu_enabled:
             self.num_GPUs = xp.cuda.runtime.getDeviceCount()
-            self.gpu_id = mpiutil.local_rank % self.num_GPUs            
+            self.gpu_id = mpiutil.local_rank % self.num_GPUs
 
     def _transfer_data(self, *args) -> Union[tuple, xp.ndarray, np.ndarray]:
         """Transfer the data between the host and device for the GPU-enabled method
@@ -287,16 +290,37 @@ class HttomolibWrapper(BaseWrapper):
             if function_name == "rotation":
                 self.wrapper_method = super()._execute_rotation
 
-        # httomolib can include GPU/CuPy methods as as well as the CPU ones. Here
-        # we check if the method can accept CuPy arrays by looking into docstrings.
+        # httomolib exports metadata from the method decorator, which we can use to
+        # check if we support CuPy
+        func = getattr(self.module, method_name)
+        self.meta = func.meta
+        self.cupyrun = self.meta.gpu
 
-        # get the docstring of a method in order to check the I/O requirements
-        get_method_docs = inspect.getdoc(getattr(self.module, method_name))
-        # if the CuPy array mentioned in the docstring then we will enable
-        # the GPU run when it is possible
-        self.cupyrun = False
-        if "cp.ndarray" in get_method_docs:
-            self.cupyrun = True
+    def calc_max_slices(
+        self,
+        dict_params: Dict,
+        slice_dim: int,
+        other_dims: Tuple[int, int],
+        dtype: np.dtype,
+        available_memory: int,
+    ) -> int:
+        # if the function does not support GPU, we return a very large value (as we don't
+        # care about limiting slices for CPU memory for now)
+        if not self.cupyrun:
+            return 1000000000
+        
+        # first we need to find the default argument value from the method meta info,
+        # before overriding those that are given (from YAML), for the kwargs arguments
+        # to calc_max_slices
+        sig: inspect.Signature = self.meta.signature
+        default_args = {}
+        for name, par in sig.parameters.items():
+            if par.default != Parameter.empty:
+                default_args[name] = par.default
+        kwargs = {**default_args, **dict_params}
+        return self.meta.calc_max_slices(
+            slice_dim, other_dims, dtype, available_memory, **kwargs
+        )
 
     def _execute_images(
         self,
@@ -317,7 +341,7 @@ class HttomolibWrapper(BaseWrapper):
 
         Returns:
             None: returns None.
-        """        
+        """
         if gpu_enabled:
             _gpumem_cleanup()
             data = getattr(self.module, method_name)(

--- a/httomo/yaml_utils.py
+++ b/httomo/yaml_utils.py
@@ -1,6 +1,6 @@
 import yaml
 import numpy as np
-from typing import List, Dict
+from typing import Any, List, Dict
 from pathlib import Path
 
 
@@ -49,7 +49,7 @@ def _get_loader():
     return loader
 
 
-def open_yaml_config(filepath: Path) -> List[Dict]:
+def open_yaml_config(filepath: Path) -> List[Dict[str, Dict[str, Dict[str, Any]]]]:
     """Open and read a given YAML config file into a python data structure.
 
     Parameters
@@ -59,7 +59,7 @@ def open_yaml_config(filepath: Path) -> List[Dict]:
 
     Returns
     -------
-    List[Dict]
+    List[Dict[str, Dict[str, Dict[str, Any]]]]
         A list of dicts, where each dict represents a task in the user config
         YAML file.
     """
@@ -84,7 +84,7 @@ def validate_yaml_config() -> bool:
     -------
     bool
     """
-    pass
+    return True
 
 
 def check_param_types() -> bool:
@@ -96,7 +96,7 @@ def check_param_types() -> bool:
     Returns
     -------
     """
-    pass
+    return True
 
 
 def generate_conf_from_prerun() -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,0 +1,44 @@
+import dataclasses
+from unittest import mock
+from mpi4py import MPI
+import numpy as np
+
+from httomo.wrappers_class import HttomolibWrapper
+
+
+def test_httomolib_wrapper_max_slices_cpu():
+    wrp = HttomolibWrapper("misc", "images", "save_to_images", MPI.COMM_WORLD)
+    assert wrp.cupyrun is False
+    assert wrp.calc_max_slices({}, 0, (100, 100), np.uint8, 50000) > 10000
+
+
+def test_httomolib_wrapper_max_slices_gpu():
+    wrp = HttomolibWrapper("prep", "normalize", "normalize", MPI.COMM_WORLD)
+    assert wrp.cupyrun is True
+    assert wrp.calc_max_slices({"flats": None}, 0, (100, 100), np.uint8, 50000) < 100000
+
+
+def test_httomolib_wrapper_max_slices_passes_kwargs():
+    from httomolib.prep.normalize import normalize
+
+    mock_method = mock.Mock()
+    mockMeta = dataclasses.replace(normalize.meta, calc_max_slices=mock_method)
+    with mock.patch.object(normalize, "meta", mockMeta):
+        wrp = HttomolibWrapper("prep", "normalize", "normalize", MPI.COMM_WORLD)
+
+        wrp.calc_max_slices(
+            dict(testarg=1, minus_log=True), 0, (100, 100), np.uint8(), 50000
+        )
+
+    # make sure the default args are called and the args given above are overriding the defaults
+    mock_method.assert_called_once_with(
+        0,
+        (100, 100),
+        np.uint8(),
+        50000,
+        cutoff=10.0,
+        minus_log=True,
+        testarg=1,
+        nonnegativity=False,
+        remove_nans=False,
+    )


### PR DESCRIPTION
This adds memory chunking for sections of GPU code with the same pattern to httomo. In particular:

- It parses the pipeline and separates it into platform sections, i.e. sequences of the pipeline that run on the same platform and don't have a reslice in the middle
- Within these sections, for those that are running on GPU only, it determines the maximum number of slices that it can fit into the available GPU memory
- Then it iterates through the methods in these sections, processing the data in chunks as needed.

Further, it refactors the task runner to use data classes and clean up the parameter passing and method descriptions, as this is necessary for a clean integration of the platform sections methods.

Note: this is still draft - not ready for merging yet.