### PR TITLE
Refactor loading

### DIFF
--- a/httomo/data/hdf/_utils/load.py
+++ b/httomo/data/hdf/_utils/load.py
@@ -433,7 +433,8 @@ def get_data_indices(
     image_key_path: str = "/entry1/instrument/image_key/image_key",
     comm: MPI.Comm = MPI.COMM_WORLD,
 ) -> List[int]:
-    """Get the indices of where the data is in a dataset.
+    """
+    Get the indices of where the data is in a dataset.
 
     Parameters
     ----------
@@ -451,11 +452,9 @@ def get_data_indices(
         indices where darks and flats are).
     """
     with h5.File(filepath, "r", driver="mpio", comm=comm) as f:
-        data_indices = []
-        for i, key in enumerate(f[image_key_path]):
-            if int(key) == 0:
-                data_indices.append(i)
-    return data_indices
+        data_indices = np.where(f[image_key_path][:] == 0)[0]
+
+    return data_indices.tolist()
 
 
 def get_slice_list_from_preview(preview: str) -> List[slice]:

--- a/httomo/data/hdf/loaders.py
+++ b/httomo/data/hdf/loaders.py
@@ -21,7 +21,7 @@ def standard_tomo(
     rotation_angles: Dict = {"data_path": "/entry1/tomo_entry/data/rotation_angle"},
     darks: Dict = None,
     flats: Dict = None,
-) -> Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, int, int, int]:
+) -> Tuple[ndarray, ndarray, ndarray, ndarray, int, int, int]:
     """Loader for standard tomography data.
 
     Parameters
@@ -56,8 +56,8 @@ def standard_tomo(
 
     Returns
     -------
-    Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, int, int, int]
-        A tuple of 8 values that all loader functions return.
+    Tuple[ndarray, ndarray, ndarray, ndarray, int, int, int]
+        A tuple of 7 values that all loader functions return.
     """
     with File(in_file, "r", driver="mpio", comm=comm) as file:
         dataset = file[data_path]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,16 @@ def standard_data():
 
 
 @pytest.fixture
+def standard_data_path():
+    return "/entry1/tomo_entry/data/data"
+
+
+@pytest.fixture
+def standard_image_key_path():
+    return "/entry1/tomo_entry/instrument/detector/image_key"
+
+
+@pytest.fixture
 def testing_pipeline():
     return "samples/pipeline_template_examples/testing/testing_pipeline.yaml"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "mpi: mark test to run in an MPI environment")
     config.addinivalue_line("markers", "perf: mark test as performance test")
     config.addinivalue_line("markers", "cupy: needs cupy to run")
+    config.addinivalue_line("markers", "slow: mark test as slow")
 
 
 def pytest_addoption(parser):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+
+from httomo.data.hdf._utils.load import load_data
+
+
+@pytest.mark.parametrize(
+    "file, dim, path_to_data, expected_shape, expected_sum, expected_mean",
+    [
+        (
+            "tests/test_data/tomo_standard.nxs",
+            1,
+            "entry1/tomo_entry/data/data",
+            (180, 128, 160),
+            2982481340,
+            809.0498426649306,
+        ),
+        (
+            "tests/test_data/tomo_standard.nxs",
+            3,
+            "entry1/tomo_entry/data/data",
+            (220, 128, 160),
+            3382481340,
+            750.7282803622159,
+        ),
+        (
+            "tests/test_data/k11_diad/k11-18014.nxs",
+            1,
+            "/entry/imaging/data",
+            (180, 22, 26),
+            3057017180,
+            29691.309052,
+        ),
+    ],
+    ids=["1d-standard", "3d-standard", "1d-diad"],
+)
+def test_load_data(
+    file, dim, path_to_data, expected_shape, expected_sum, expected_mean
+):
+    preview = "0:180, :, :"
+    output = load_data(file, dim, path_to_data, preview, comm=comm)
+
+    assert output.shape == expected_shape
+    assert output.dtype == np.uint16
+    assert output.sum() == expected_sum
+    np.testing.assert_allclose(output.mean(), expected_mean, rtol=1e-6)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -85,3 +85,40 @@ def test_standard_tomo(standard_data, standard_data_path, standard_image_key_pat
     assert output[4] == 180  # angles_total
     assert output[5] == 5  # detector_y
     assert output[6] == 160  # detector_x
+
+
+def test_diad_loader():
+    in_file = "tests/test_data/k11_diad/k11-18014.nxs"
+    data_path = "/entry/imaging/data"
+    image_key_path = "/entry/instrument/imaging/image_key"
+    rotation_angles = {"data_path": "/entry/imaging_sum/gts_theta_value"}
+
+    output = standard_tomo(
+        "tomo",
+        in_file,
+        data_path,
+        1,
+        [None, {'start': 5, 'stop': 7}, None],
+        0,
+        comm,
+        image_key_path=image_key_path,
+        rotation_angles=rotation_angles,
+    )
+
+    assert len(output) == 7
+
+    assert output[0].sum() == 6019533062
+    np.testing.assert_allclose(output[0].mean(), 38573.89243329147, rtol=1e-5)
+    assert output[0].shape == (3001, 2, 26)
+
+    assert output[1].sum() == 236484277
+    np.testing.assert_allclose(output[1].mean(), 45477.74557692308, rtol=1e-5)
+    assert output[1].shape == (100, 2, 26)
+
+    assert output[3].shape == (3001,)
+    np.testing.assert_allclose(output[3].sum(), 9427.76925660484, rtol=1e-5)
+    np.testing.assert_allclose(output[3].mean(), 3.1415425713444987, rtol=1e-5)
+
+    assert output[4] == 3001
+    assert output[5] == 2
+    assert output[6] == 26

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -32,6 +32,7 @@ def test_tomo_standard_testing_pipeline_loaded(
 
 
 @pytest.mark.cupy
+@pytest.mark.slow
 def test_diad_testing_pipeline_loaded(
     cmd, diad_data, diad_loader, output_folder, testing_pipeline, merge_yamls
 ):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,12 @@
 import pytest
 import subprocess
+import numpy as np
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+
+from httomo.data.hdf.loaders import standard_tomo
 
 
 @pytest.mark.cupy
@@ -42,3 +49,39 @@ def test_diad_testing_pipeline_loaded(
     assert "Running task 5 (pattern=sinogram): find_center_vo..." in result.stderr
     assert "Running task 7 (pattern=all): save_to_images.." in result.stderr
     assert "Pipeline finished" in result.stderr
+
+
+def test_standard_tomo(standard_data, standard_data_path, standard_image_key_path):
+    preview = [None, {"start": 5, "stop": 10}, None]
+
+    output = standard_tomo(
+        "tomo",
+        standard_data,
+        standard_data_path,
+        1,
+        preview,
+        1,
+        comm,
+        image_key_path=standard_image_key_path,
+    )
+
+    assert len(output) == 7
+
+    # data
+    assert output[0].sum() == 141348397
+    np.testing.assert_allclose(output[0].mean(), 981.58574794, rtol=1e-5)
+    assert output[0].shape == (180, 5, 160)
+
+    # flats
+    assert output[1].sum() == 15625259
+    np.testing.assert_allclose(output[1].mean(), 976.5786875, rtol=1e-5)
+    assert output[1].shape == (20, 5, 160)
+
+    # angles
+    assert output[3].shape == (180,)
+    np.testing.assert_allclose(output[3].sum(), 281.1725424962865, rtol=1e-5)
+    np.testing.assert_allclose(output[3].mean(), 1.562069680534925, rtol=1e-5)
+
+    assert output[4] == 180  # angles_total
+    assert output[5] == 5  # detector_y
+    assert output[6] == 160  # detector_x

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import re
 import subprocess
 
@@ -146,6 +147,7 @@ def test_tomo_standard_testing_pipeline_output_with_save_all(
 
 
 @pytest.mark.cupy
+@pytest.mark.slow
 def test_diad_testing_pipeline_output(
     cmd, diad_data, diad_loader, testing_pipeline, output_folder, merge_yamls
 ):


### PR DESCRIPTION
This is an attempt to refactor [`load.py`](https://github.com/DiamondLightSource/httomo/blob/main/httomo/data/hdf/_utils/load.py) & [`loaders.py`](https://github.com/DiamondLightSource/httomo/blob/main/httomo/data/hdf/loaders.py) and see if we get some speedups.
- [x] add tests for `load_data` before refactoring
- [x] add tests for `standard_tomo` from loaders.py before refactoring
- [x] merge `read_through_dim1`, `read_through_dim2`, `read_through_dim3` into one function
- [x] Improve the performance of `get_data_indices` function by using a vectorized implementation (avoid `for` loops, use `np.where` and finally return a list)
- [x] remove all occurrences of `round` from the file (used integer division `//` which is faster than using `/` + `round`)
- [ ] .. 

Fixes #27 