### PR TITLE
Copy YAML pipeline file to output dir prior to run

### DIFF
--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 from datetime import datetime
+from shutil import copy
 
 import click
 
@@ -109,6 +110,9 @@ def main(
     if comm.rank == 0:
         # Setup global logger object
         httomo.globals.logger = setup_logger(httomo.globals.run_out_dir)
+
+        # Copy YAML pipeline file to output directory
+        copy(yaml_config, httomo.globals.run_out_dir)
 
     if ctx.invoked_subcommand is None:
         click.echo(main.get_help(ctx))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -44,7 +44,16 @@ def test_tomo_standard_testing_pipeline_output(
 
     # recurse through output_dir and check that all files are there
     files = read_folder("output_dir/")
-    assert len(files) == 5
+    assert len(files) == 6
+
+    # check that the contents of the copied YAML in the output directory matches
+    # the contents of the input YAML
+    copied_yaml_path = list(filter(lambda x: ".yaml" in x, files)).pop()
+    with open("temp.yaml", "r") as original_yaml:
+        original_text = original_yaml.read()
+    with open(copied_yaml_path, "r") as copied_yaml:
+        copied_text = copied_yaml.read()
+    assert copied_text == original_text
 
     # check the .tif files
     tif_files = list(filter(lambda x: ".tif" in x, files))
@@ -96,7 +105,16 @@ def test_tomo_standard_testing_pipeline_output_with_save_all(
     subprocess.check_output(cmd)
 
     files = read_folder("output_dir/")
-    assert len(files) == 8
+    assert len(files) == 9
+
+    # check that the contents of the copied YAML in the output directory matches
+    # the contents of the input YAML
+    copied_yaml_path = list(filter(lambda x: ".yaml" in x, files)).pop()
+    with open("temp.yaml", "r") as original_yaml:
+        original_text = original_yaml.read()
+    with open(copied_yaml_path, "r") as copied_yaml:
+        copied_text = copied_yaml.read()
+    assert copied_text == original_text
 
     # check the .tif files
     tif_files = list(filter(lambda x: ".tif" in x, files))
@@ -133,7 +151,16 @@ def test_diad_testing_pipeline_output(
     subprocess.check_output(cmd)
 
     files = read_folder("output_dir/")
-    assert len(files) == 7
+    assert len(files) == 8
+
+    # check that the contents of the copied YAML in the output directory matches
+    # the contents of the input YAML
+    copied_yaml_path = list(filter(lambda x: ".yaml" in x, files)).pop()
+    with open("temp.yaml", "r") as original_yaml:
+        original_text = original_yaml.read()
+    with open(copied_yaml_path, "r") as copied_yaml:
+        copied_text = copied_yaml.read()
+    assert copied_text == original_text
 
     #: check the .tif files
     tif_files = list(filter(lambda x: ".tif" in x, files))


### PR DESCRIPTION
This is a fairly basic change so there's not much to say. One comment is that, with Savu runs, there is a separation of output data from logfiles by putting the logfiles and copied process list file into a subdirectory called `run_log/`, like so (I've ignored some other irrelevant subdirectories in the output below to keep it tidy):
```
[twi18192@pc0074 20221119164836_119497]$ tree -I 'checkpoint|stats'
.
├── 119497_processed.nxs
├── cor_broadcast_p2_vo_centering.h5
├── cor_preview_p2_vo_centering.h5
├── run_log
│   ├── citations.txt
│   ├── run_command.txt
│   ├── savu_benchmark.savu
│   └── user.log
├── tomo_p1_dark_flat_field_correction.h5
├── tomo_p3_remove_all_rings.h5
└── tomo_p4_astra_recon_gpu.h5

1 directory, 10 files
```

So, maybe that's something we would want to do in the future?

But so far, I've only plonked the copied YAML file into the same directory as the output data and logfile, like so:
```
[twi18192@pc0074 04-05-2023_16_27_44_output (copy-input-yaml)]$ tree
.
├── 5-tomopy-recon-tomo-gridrec.h5
├── i12-data-cpu.yaml
└── user.log

0 directories, 3 files
```