### PR TITLE
CPU-only httomo for CPU tests?

### DIFF
--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -29,10 +29,9 @@ jobs:
       # install dependencies with conda
       - name: Install dependencies with conda
         run: |
-          conda env create --name httomo --file conda/environment.yml
-          conda activate httomo
+          conda env create --name httomo --file conda/environment-cpu.yml
           conda run -n httomo pip install -e .
-          conda run -n httomo pip install httomolib
+          conda run -n httomo pip install git+https://github.com/DiamondLightSource/httomolib.git@httomo-cpu
           conda env list
           conda list
 
@@ -40,4 +39,4 @@ jobs:
       - name: Run CPU tests (No CUDA drivers needed)
         run: |
           conda run -n httomo pip install pytest
-          conda run -n httomo pytest -m "not cupy"
+          conda run -n httomo pytest

--- a/conda/environment-cpu.yml
+++ b/conda/environment-cpu.yml
@@ -1,0 +1,13 @@
+name: httomo
+channels:
+  - conda-forge
+  - anaconda
+dependencies:
+  - conda-forge::click
+  - conda-forge::mpi4py>=3.1
+  - conda-forge::h5py==3.8.0[build=*openmpi*]
+  - conda-forge::pyyaml
+  - conda-forge::numpy<1.24
+  - conda-forge::python
+  - anaconda::ipython
+  - conda-forge::tomopy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ requires-python = ">=3.9"
 version = "0.0.1"
 dependencies = [
     "click",
-    "cupy",
     "numpy",
 ]
 
@@ -54,7 +53,7 @@ repository = "https://github.com/DiamondLightSource/HTTomo"
 
 [project.optional-dependencies]
 tomopy = [ "tomopy" ]
-httomolib = [ "httomolib" ]
+httomolib = [ "httomolib", "cupy" ]
 dev = [
   "pytest",
   "pytest-cov",


### PR DESCRIPTION
After dealing with https://github.com/DiamondLightSource/httomo/pull/134 I noticed that it would have been caught much sooner if even a *single* pipeline was executable on CI. This of course isn't possible yet due to requiring GPU-support even when httomo is running a CPU-only pipeline.

I was curious how much effort would be needed to make httomo work with only CPU dependencies, and it didn't seem like too much at a first attempt.

And by the way, with this PR, I'm not suggesting that this should definitely go into `main`; the PR is mainly to trigger the CI.

Feel free to comment if interested!