### PR TITLE
Add CLI flag for naming the output dir created by HTTomo

### DIFF
--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -86,6 +86,12 @@ def check(yaml_config: Path, in_data: Path = None):
     else context.params["out_dir"],
     help="Directory for reslice intermediate files (defaults to out_dir, only relevant if --reslice is also given)",
 )
+@click.option(
+    "--output-folder",
+    type=click.Path(exists=False, file_okay=False, writable=True, path_type=Path),
+    default=None,
+    help="Optionally define the name of the output folder created by HTTomo",
+)
 def run(
     in_file: Path,
     yaml_config: Path,
@@ -96,12 +102,16 @@ def run(
     save_all: bool,
     file_based_reslice: bool,
     reslice_dir: Path,
+    output_folder: Path,
 ):
     """Run a processing pipeline defined in YAML on input data."""
     # Define httomo.globals.run_out_dir in all MPI processes
-    httomo.globals.run_out_dir = out_dir.joinpath(
-        f"{datetime.now().strftime('%d-%m-%Y_%H_%M_%S')}_output"
-    )
+    if output_folder is None:
+        httomo.globals.run_out_dir = out_dir.joinpath(
+            f"{datetime.now().strftime('%d-%m-%Y_%H_%M_%S')}_output"
+        )
+    else:
+        httomo.globals.run_out_dir = out_dir.joinpath(output_folder)
     comm = MPI.COMM_WORLD
     if comm.rank == 0:
         # Setup global logger object

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import pytest
 import subprocess
 import sys
+from pathlib import Path
 
 from httomo import __version__
 
@@ -39,3 +40,26 @@ def test_cli_check_pass_data_file(standard_loader, standard_data):
         "match the paths and keys in the input file (IN_DATA)..."
     )
     assert check_data_str in subprocess.check_output(cmd).decode().strip()
+
+
+@pytest.mark.cupy
+def test_cli_pass_output_folder(
+    standard_data, standard_loader, testing_pipeline, merge_yamls, output_folder
+):
+    merge_yamls(standard_loader, testing_pipeline)
+    output_dir = "output_dir"  # dir created by the `output_folder` fixture
+    httomo_output_dir = "test-output"  # subdir that should be created by httomo
+    custom_output_dir = Path(output_dir, httomo_output_dir)
+    cmd = [
+        sys.executable,
+        "-m",
+        "httomo",
+        "run",
+        "--output-folder",
+        httomo_output_dir,
+        standard_data,
+        "temp.yaml",
+        output_dir,
+    ]
+    subprocess.check_output(cmd)
+    assert Path(custom_output_dir, "user.log").exists()


### PR DESCRIPTION
Not much explanation needed I guess, pretty simple.

Fixes #131.