### PR TITLE
360 scan pipeline (GPU), data, test

### DIFF
--- a/httomo/postrun.py
+++ b/httomo/postrun.py
@@ -47,9 +47,13 @@ def postrun_method(
 
     # Save the result if necessary
     if run_method_info.save_result and is_3d and not any_param_sweep:
-        recon_algorithm = run_method_info.dict_params_method.pop("algorithm", None)
-        if recon_algorithm is not None:
+        recon_center = run_method_info.dict_params_method.pop("center", None)
+        recon_algorithm = None
+        if recon_center is not None:
             slice_dim = 1
+            recon_algorithm = run_method_info.dict_params_method.pop(
+                "algorithm", None
+            )  # covers tomopy case
         else:
             slice_dim = _get_slicing_dim(current_func.pattern)
 

--- a/httomo/prerun.py
+++ b/httomo/prerun.py
@@ -26,7 +26,6 @@ def prerun_method(
     glob_stats: Dict,
     reslice_info: ResliceInfo,
 ):
-
     run_method_info.package_name = current_func.module_name.split(".")[0]
     dict_params_method = current_func.parameters
     run_method_info.method_name = current_func.method_func.__name__
@@ -45,7 +44,9 @@ def prerun_method(
     )
 
     # Check if the input dataset should be resliced before the task runs
-    run_method_info.should_reslice = reslice_info.reslice_bool_list[run_method_info.task_idx]
+    run_method_info.should_reslice = reslice_info.reslice_bool_list[
+        run_method_info.task_idx
+    ]
     if run_method_info.should_reslice:
         reslice_info.count += 1
         run_method_info.current_slice_dim = _get_slicing_dim(prev_func.pattern)

--- a/samples/pipeline_template_examples/DLS/02_i12_360scan_pipeline.yaml
+++ b/samples/pipeline_template_examples/DLS/02_i12_360scan_pipeline.yaml
@@ -7,15 +7,9 @@
       preview:
         - 
         - start: 30
-          stop: 60
+          stop: 38
         - 
       pad: 0
-- httomolibgpu.misc.corr:
-    remove_outlier3d:
-      data_in_multi: [tomo, flats, darks]
-      data_out_multi: [tomo, flats, darks]
-      kernel_size: 3
-      dif: 0.1      
 - httomolibgpu.prep.normalize:
     normalize:
       data_in: tomo
@@ -46,7 +40,7 @@
       overlap: overlap
       rotation: right 
 - httomolibgpu.recon.algorithm:
-     reconstruct_tomobar:
+     FBP:
        data_in: tomo
        data_out: tomo
        center: cor

--- a/samples/pipeline_template_examples/DLS/02_i12_360scan_pipeline.yaml
+++ b/samples/pipeline_template_examples/DLS/02_i12_360scan_pipeline.yaml
@@ -6,8 +6,7 @@
       dimension: 1
       preview:
         - 
-        - start: 30
-          stop: 38
+        -
         - 
       pad: 0
 - httomolibgpu.prep.normalize:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,13 @@ def diad_loader():
 def i12_data():
     return "tests/test_data/i12/separate_flats_darks/i12_dynamic_start_stop180.nxs"
 
+@pytest.fixture
+def data360():
+    return "tests/test_data/360scan/360scan.hdf"
+
+@pytest.fixture
+def pipeline360():
+    return "samples/pipeline_template_examples/DLS/02_i12_360scan_pipeline.yaml"
 
 @pytest.fixture
 def i12_loader():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,13 +99,16 @@ def diad_loader():
 def i12_data():
     return "tests/test_data/i12/separate_flats_darks/i12_dynamic_start_stop180.nxs"
 
+
 @pytest.fixture
 def data360():
     return "tests/test_data/360scan/360scan.hdf"
 
+
 @pytest.fixture
 def pipeline360():
     return "samples/pipeline_template_examples/DLS/02_i12_360scan_pipeline.yaml"
+
 
 @pytest.fixture
 def i12_loader():

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -7,7 +7,6 @@ from httomo.data.hdf._utils.load import load_data
 comm = MPI.COMM_WORLD
 
 
-
 @pytest.mark.parametrize(
     "file, dim, path_to_data, expected_shape, expected_sum, expected_mean",
     [

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -9,7 +9,6 @@ from httomo.data.hdf.loaders import standard_tomo
 comm = MPI.COMM_WORLD
 
 
-
 def test_tomo_standard_testing_pipeline_loaded(
     cmd, standard_data, standard_loader, output_folder, testing_pipeline, merge_yamls
 ):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -186,9 +186,7 @@ def test_gpu_pipeline_output_with_save_all(
 
 
 @pytest.mark.cupy
-def test_gpu_pipeline_360data(
-    cmd, data360, pipeline360, output_folder
-):
+def test_gpu_pipeline_360data(cmd, data360, pipeline360, output_folder):
     cmd.insert(7, data360)
     cmd.insert(8, pipeline360)
     subprocess.check_output(cmd)
@@ -206,15 +204,15 @@ def test_gpu_pipeline_360data(
         total_sum += arr.sum()
 
     assert total_sum == 2316612878.0
-    
+
     h5_files = list(filter(lambda x: ".h5" in x, files))
     assert len(h5_files) == 4
-    
+
     fpb_recon_tomo = list(filter(lambda x: "FBP-tomo.h5" in x, h5_files))[0]
-    
+
     with h5py.File(fpb_recon_tomo, "r") as f:
         assert_allclose(np.sum(f["data"]), 17200.271, atol=1e-5)
-        assert_allclose(np.mean(f["data"]), 0.000572, atol=1e-5)    
+        assert_allclose(np.mean(f["data"]), 0.000572, atol=1e-5)
 
 
 def test_i12_testing_pipeline_output(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -185,6 +185,21 @@ def test_gpu_pipeline_output_with_save_all(
         assert f["data"].shape == (180, 128, 160)
 
 
+@pytest.mark.cupy
+def test_gpu_pipeline_360data(
+    cmd, data360, pipeline360, output_folder
+):
+    cmd.insert(7, data360)
+    cmd.insert(8, pipeline360)
+    subprocess.check_output(cmd)
+
+    files = read_folder("output_dir/")
+    assert len(files) == 9
+
+    tif_files = list(filter(lambda x: ".tif" in x, files))
+    assert len(tif_files) == 3
+
+
 def test_i12_testing_pipeline_output(
     cmd, i12_data, i12_loader, testing_pipeline, output_folder, merge_yamls
 ):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -198,6 +198,23 @@ def test_gpu_pipeline_360data(
 
     tif_files = list(filter(lambda x: ".tif" in x, files))
     assert len(tif_files) == 3
+    total_sum = 0
+    for i in range(3):
+        arr = np.array(Image.open(tif_files[i]))
+        assert arr.dtype == np.uint8
+        assert arr.shape == (3167, 3167)
+        total_sum += arr.sum()
+
+    assert total_sum == 2316612878.0
+    
+    h5_files = list(filter(lambda x: ".h5" in x, files))
+    assert len(h5_files) == 4
+    
+    fpb_recon_tomo = list(filter(lambda x: "FBP-tomo.h5" in x, h5_files))[0]
+    
+    with h5py.File(fpb_recon_tomo, "r") as f:
+        assert_allclose(np.sum(f["data"]), 17200.271, atol=1e-5)
+        assert_allclose(np.mean(f["data"]), 0.000572, atol=1e-5)    
 
 
 def test_i12_testing_pipeline_output(


### PR DESCRIPTION
deal with #150 
Adding 360 degrees scan sample data, fixes the pipeline and adds the test.

also adds a fix for the post_run with intermediate data saving. 