### PR TITLE
Move reslice to section loop

### DIFF
--- a/httomo/common.py
+++ b/httomo/common.py
@@ -35,8 +35,6 @@ class MethodFunc:
         Whether CPU execution is supported.
     gpu : bool
         Whether GPU execution is supported.
-    reslice_ahead : bool
-        Whether a reslice needs to be done due to a pattern change in the pipeline
     is_last_method : bool
         True if it is the last method in the pipeline
     """
@@ -49,7 +47,6 @@ class MethodFunc:
     pattern: Pattern = Pattern.projection
     cpu: bool = True
     gpu: bool = False
-    reslice_ahead: bool = False
     is_loader: bool = False
     is_last_method: bool = False
 
@@ -118,16 +115,10 @@ class RunMethodInfo:
         The name of the input dataset
     data_out : Union[str, List[str]]
         The name(s) of the output dataset(s)
-    should_reslice : bool
-        To check if the input dataset should be resliced before the task runs
     dict_httomo_params : Dict
         Dict containing extra params unrelated to wrapped packages but related to httomo
     save_result : bool
         Bool to check if we need to save the result (e.g., if it is the last method)
-    current_slice_dim : int
-        the dimension of the data that the current method requires the data to be sliced in.
-    next_slice_dim : int
-        the dimension of the data that the next method requires the data to be sliced in
     task_idx: int
         Index of the task in the pipeline being run
     package_name: str
@@ -139,11 +130,8 @@ class RunMethodInfo:
     dict_params_method: Dict[str, Any] = field(default_factory=dict)
     data_in: str = field(default_factory=str)
     data_out: Union[str, List[str]] = field(default_factory=str)
-    should_reslice: bool = False
     dict_httomo_params: Dict[str, Any] = field(default_factory=dict)
     save_result: bool = False
-    current_slice_dim: int = -1
-    next_slice_dim: int = -1
     task_idx: int = -1
     package_name: str = None
     method_name: str = None

--- a/httomo/common.py
+++ b/httomo/common.py
@@ -93,12 +93,16 @@ class PlatformSection:
         exhausting memory (relevant on GPU only)
     methods : List[MethodFunc]
         List of methods in this section
+    output_stats : Tuple[int, int, float, float]
+        A tuple containing the min, max, mean, and standard deviation of the
+        output of the final method in the section
     """
 
     gpu: bool
     pattern: Pattern
     max_slices: int
     methods: List[MethodFunc]
+    output_stats: Tuple[int, int, float, float]
 
 
 @dataclass

--- a/httomo/common.py
+++ b/httomo/common.py
@@ -66,8 +66,6 @@ class ResliceInfo:
         Counter for how many reslices were done so far
     has_warn_printed : bool
         Whether the reslicing warning has been printed
-    reslice_bool_list : List[bool]
-        List of booleans to identify when reslicing is needed
     reslice_dir : Optional[Path]
         The directory to use with file-based reslicing. If None,
         reslicing will be done in-memory.
@@ -75,7 +73,6 @@ class ResliceInfo:
 
     count: int
     has_warn_printed: bool
-    reslice_bool_list: List[bool]
     reslice_dir: Optional[Path] = None
 
 

--- a/httomo/prerun.py
+++ b/httomo/prerun.py
@@ -21,7 +21,6 @@ def prerun_method(
     misc_params: List[Tuple[List[str], object]],
     current_func: MethodFunc,
     dict_datasets_pipeline: Dict[str, ndarray],
-    glob_stats: Dict,
 ):
 
     run_method_info.package_name = current_func.module_name.split(".")[0]

--- a/httomo/prerun.py
+++ b/httomo/prerun.py
@@ -20,8 +20,6 @@ def prerun_method(
     save_all: int,
     misc_params: List[Tuple[List[str], object]],
     current_func: MethodFunc,
-    prev_func: MethodFunc,
-    next_func: MethodFunc,
     dict_datasets_pipeline: Dict[str, ndarray],
     glob_stats: Dict,
 ):

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -530,7 +530,6 @@ def run_method(
         misc_params,
         current_func,
         dict_datasets_pipeline,
-        glob_stats,
     )
 
     # Assign the `data` parameter of the method to the array associated with its

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -305,8 +305,6 @@ def run_tasks(
             save_all,
             possible_extra_params,
             method_func,
-            method_funcs[idx - 1],
-            method_funcs[idx + 1] if idx < len(method_funcs) - 1 else None,
             dict_datasets_pipeline,
             glob_stats[idx],
             comm,
@@ -486,8 +484,6 @@ def run_method(
     save_all: bool,
     misc_params: List[Tuple[List[str], object]],
     current_func: MethodFunc,
-    prev_func: MethodFunc,
-    next_func: Optional[MethodFunc],
     dict_datasets_pipeline: Dict[str, Optional[ndarray]],
     glob_stats: Dict,
     comm: MPI.Comm,
@@ -505,11 +501,6 @@ def run_method(
         A list of possible extra params that may be needed by a method.
     current_func : MethodFunc
         Object describing the python function that performs the method.
-    prev_func : MethodFunc
-        Object describing the python function that performed the previous method in the pipeline.
-    next_func: Optional[MethodFunc]
-        Object describing the python function that is next in the pipeline,
-        unless the current method is the last one.
     dict_datasets_pipeline : Dict[str, ndarray]
         A dict containing all available datasets in the given pipeline.
     glob_stats : Dict
@@ -538,8 +529,6 @@ def run_method(
         save_all,
         misc_params,
         current_func,
-        prev_func,
-        next_func,
         dict_datasets_pipeline,
         glob_stats,
     )

--- a/httomo/wrappers_class.py
+++ b/httomo/wrappers_class.py
@@ -59,7 +59,6 @@ class BaseWrapper:
         method_name: str,
         dict_params_method: Dict,
         data: xp.ndarray,
-        reslice_ahead: bool,
         save_result: bool,
     ) -> xp.ndarray:
         """The generic wrapper to execute functions for external packages.
@@ -68,7 +67,6 @@ class BaseWrapper:
             method_name (str): The name of the method to use.
             dict_params_method (Dict): A dict containing parameters of the executed method.
             data (xp.ndarray): a numpy or cupy data array.
-            reslice_ahead (bool): a bool to inform the wrapper if the reslice ahead and the conversion to numpy required.
             save_result (bool): if data is saved then the conversion to numpy required.
 
         Returns:
@@ -91,7 +89,6 @@ class BaseWrapper:
         data: xp.ndarray,
         flats: xp.ndarray,
         darks: xp.ndarray,
-        reslice_ahead: bool,
         save_result: bool,
     ) -> xp.ndarray:
         """Normalisation-specific wrapper when flats and darks are required.
@@ -102,7 +99,6 @@ class BaseWrapper:
             data (xp.ndarray): a numpy or cupy data array.
             flats (xp.ndarray): a numpy or cupy flats array.
             darks (xp.ndarray): a numpy or darks flats array.
-            reslice_ahead (bool): a bool to inform the wrapper if the reslice ahead and the conversion to numpy required.
             save_result (bool): if data is saved then the conversion to numpy required.
 
         Returns:
@@ -122,7 +118,6 @@ class BaseWrapper:
         dict_params_method: Dict,
         data: xp.ndarray,
         angles_radians: np.ndarray,
-        reslice_ahead: bool,
         save_result: bool,
     ) -> xp.ndarray:
         """The reconstruction wrapper.
@@ -132,7 +127,6 @@ class BaseWrapper:
             dict_params_method (Dict): A dict containing parameters of the executed method.
             data (xp.ndarray): a numpy or cupy data array.
             angles_radians (np.ndarray): a numpy array of projection angles.
-            reslice_ahead (bool): a bool to inform the wrapper if the reslice ahead and the conversion to numpy required.
             save_result (bool): if data is saved then the conversion to numpy required.
 
         Returns:

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -139,6 +139,7 @@ def test_platform_section_max_slices():
         gpu=True,
         pattern=Pattern.projection,
         max_slices=0,
+        output_stats=None,
         methods=[
             make_test_method(
                 pattern=Pattern.projection, gpu=True, calc_max_slices=max_slices_20


### PR DESCRIPTION
This has moved the reslice operation from the `run_method()` function to the sections-loop.

Note that the execution of methods is still in `run_method()`, so the current state is the following:
- reslices are being done within the sections-loop
- the sections-loop is not executing any methods yet
- _after_ the sections-loop finishes, methods are executed via a loop calling `run_method()`

Therefore, the reslices are **not** happening in the correct places in the execution of the pipeline. Once the execution of the methods has been moved to the methods-loop (the innermost loop within the sections-loop), this should be resolved.