### PR TITLE
Add loader params for ignoring darks/flats

### DIFF
--- a/docs/source/reference/loaders.rst
+++ b/docs/source/reference/loaders.rst
@@ -1,6 +1,117 @@
 .. _reference_loaders:
 
 HTTomo Loaders
---------------------------
+--------------
 
-TODO.
+Ignoring darks and/or flats
+===========================
+
+There are situations where certain dark or flat fields that have been collected
+in the data need to be excluded from processing. The standard tomography loader
+in HTTomo offers the functionality to exclude darks and/or flat field images
+based on their index in the dataset they are contained in. The images can be
+excluded by specifying either:
+
+- Individual indices
+- A range of indices with start and stop values
+
+This functionality is used in a process list via the :code:`ignore_darks` and
+:code:`ignore_flats` parameters.
+
+To specify individual indices to exclude, use the :code:`individual` subfield,
+and to specify a range of indices to exclude, use the :code:`batch` subfield.
+These subfields can both be used at the same time to select batches of
+darks/flats as well as individual darks/flats to ignore.
+
+It is also possible to ignore *all* darks and/or flats by setting the value of
+either :code:`ignore_darks` or :code:`ignore_flats` to :code:`true`.
+
+Below shows some example uses of the :code:`ignore_darks` parameter, and the
+:code:`ignore_flats` parameter can be used in a similar manner.
+
+Ignore individual darks only
+++++++++++++++++++++++++++++
+
+.. code-block:: yaml
+  :emphasize-lines: 12-13
+
+    - httomo.data.hdf.loaders:
+        standard_tomo:
+        name: tomo
+        data_path: entry1/tomo_entry/data/data
+        image_key_path: entry1/tomo_entry/instrument/detector/image_key
+        dimension: 1
+        preview:
+            -
+            - start: 30
+              stop: 60
+            -
+        ignore_darks:
+            individual: [0, 5]
+
+Ignore all darks
+++++++++++++++++
+
+.. code-block:: yaml
+  :emphasize-lines: 12
+
+    - httomo.data.hdf.loaders:
+        standard_tomo:
+        name: tomo
+        data_path: entry1/tomo_entry/data/data
+        image_key_path: entry1/tomo_entry/instrument/detector/image_key
+        dimension: 1
+        preview:
+            -
+            - start: 30
+              stop: 60
+            -
+        ignore_darks: true
+
+Ignore individual darks and a group of darks
+++++++++++++++++++++++++++++++++++++++++++++
+
+.. code-block:: yaml
+  :emphasize-lines: 12-16
+
+    - httomo.data.hdf.loaders:
+        standard_tomo:
+        name: tomo
+        data_path: entry1/tomo_entry/data/data
+        image_key_path: entry1/tomo_entry/instrument/detector/image_key
+        dimension: 1
+        preview:
+            -
+            - start: 30
+              stop: 60
+            -
+        ignore_darks:
+          individual: [0, 3]
+          batch:
+            - start: 5
+              stop: 10
+
+
+Ignore two groups of darks
+++++++++++++++++++++++++++
+
+.. code-block:: yaml
+  :emphasize-lines: 12-17
+
+    - httomo.data.hdf.loaders:
+        standard_tomo:
+        name: tomo
+        data_path: entry1/tomo_entry/data/data
+        image_key_path: entry1/tomo_entry/instrument/detector/image_key
+        dimension: 1
+        preview:
+            -
+            - start: 30
+              stop: 60
+            -
+        ignore_darks:
+          batch:
+            - start: 5
+              stop: 10
+            - start: 20
+              stop: 30

--- a/httomo/data/hdf/_utils/load.py
+++ b/httomo/data/hdf/_utils/load.py
@@ -476,12 +476,26 @@ def get_darks_flats_together(
                 darks_indices = []
             elif isinstance(ignore_darks, dict):
                 ignore_darks_indices = _parse_ignore_darks_flats(ignore_darks)
+                if not set(ignore_darks_indices) <= set(darks_indices):
+                    err_str = (
+                        f"The darks indices to ignore are "
+                        f"{ignore_darks_indices}, which has one or "
+                        f"more values outside the darks in the dataset."
+                    )
+                    raise ValueError(err_str)
                 darks_indices = list(set(darks_indices) - set(ignore_darks_indices))
             # Get indices of flats to ignore (if any)
             if ignore_flats is True:
                 flats_indices = []
             elif isinstance(ignore_flats, dict):
                 ignore_flats_indices = _parse_ignore_darks_flats(ignore_flats)
+                if not set(ignore_flats_indices) <= set(flats_indices):
+                    err_str = (
+                        f"The flats indices to ignore are "
+                        f"{ignore_flats_indices}, which has one or "
+                        f"more values outside the flats in the dataset."
+                    )
+                    raise ValueError(err_str)
                 flats_indices = list(set(flats_indices) - set(ignore_flats_indices))
             dataset = file[data_path]
             darks = _get_darks_flats(dataset, darks_indices, dim, pad, preview, comm)
@@ -547,6 +561,13 @@ def get_darks_flats_separate(
             indices = []
         elif isinstance(ignore_indices, dict):
             ignore_indices = _parse_ignore_darks_flats(ignore_indices)
+            if not set(ignore_indices) <= set(indices):
+                err_str = (
+                    f"The darks/flats indices to ignore are "
+                    f"{ignore_indices}, which has one or more values "
+                    f"outside the darks/flats in the dataset."
+                )
+                raise ValueError(err_str)
             indices = list(set(indices) - set(ignore_indices))
         data = _get_darks_flats(dataset, indices, dim, pad, preview, comm)
     return data

--- a/httomo/data/hdf/loaders.py
+++ b/httomo/data/hdf/loaders.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from h5py import File
 from mpi4py.MPI import Comm
@@ -36,6 +36,8 @@ def standard_tomo(
     },
     darks: Optional[Dict] = None,
     flats: Optional[Dict] = None,
+    ignore_darks: Optional[Union[bool, Dict]] = False,
+    ignore_flats: Optional[Union[bool, Dict]] = False,
 ) -> LoaderData:
     """Loader for standard tomography data.
 
@@ -70,6 +72,12 @@ def standard_tomo(
     flats : optional, Dict
         A dict containing filepath and dataset information about the flats if
         they are not in the same dataset as the data.
+    ignore_darks : optional, Union[bool, Dict]
+        If bool, specifies ignoring all or none of darks. If dict, specifies
+        individual and batch darks to ignore.
+    ignore_flats : optional, Union[bool, Dict]
+        If bool, specifies ignoring all or none of flats. If dict, specifies
+        individual and batch flats to ignore.
 
     Returns
     -------
@@ -136,10 +144,18 @@ def standard_tomo(
         # Get darks and flats from different datasets within different NeXuS
         # files
         darks_data = load.get_darks_flats_separate(
-            darks["file"], darks["data_path"], dim=dimension, preview=preview_str
+            darks["file"],
+            darks["data_path"],
+            dim=dimension,
+            preview=preview_str,
+            ignore_indices=ignore_darks,
         )
         flats_data = load.get_darks_flats_separate(
-            flats["file"], flats["data_path"], dim=dimension, preview=preview_str
+            flats["file"],
+            flats["data_path"],
+            dim=dimension,
+            preview=preview_str,
+            ignore_indices=ignore_flats,
         )
     elif darks is not None and flats is not None and darks["file"] == flats["file"]:
         # Get darks and flats from different datasets within the same NeXuS file
@@ -149,6 +165,8 @@ def standard_tomo(
             darks_path=darks["data_path"],
             flats_path=flats["data_path"],
             image_key_path=image_key_path,
+            ignore_darks=ignore_darks,
+            ignore_flats=ignore_flats,
             comm=comm,
             preview=preview_str,
             dim=dimension,
@@ -159,6 +177,8 @@ def standard_tomo(
             str(in_file),
             data_path,
             image_key_path=image_key_path,
+            ignore_darks=ignore_darks,
+            ignore_flats=ignore_flats,
             comm=comm,
             preview=preview_str,
             dim=dimension,

--- a/samples/pipeline_template_examples/DLS/04_i12_ignore_darks_flats.yaml
+++ b/samples/pipeline_template_examples/DLS/04_i12_ignore_darks_flats.yaml
@@ -1,0 +1,24 @@
+- httomo.data.hdf.loaders:
+    standard_tomo:
+      name: tomo
+      data_path: /1-TempPlugin-tomo/data
+      rotation_angles:
+        user_defined:
+          start_angle: 0
+          stop_angle: 180
+          angles_total: 724
+      dimension: 1
+      preview: [null, null, null]
+      pad: 0
+      darks:
+        file: tests/test_data/i12/separate_flats_darks/dark_field.h5
+        data_path: /1-NoProcessPlugin-tomo/data
+      ignore_darks:
+        individual: [0, 5, 8, 10, 15]
+      flats:
+        file: tests/test_data/i12/separate_flats_darks/flat_field.h5
+        data_path: /1-NoProcessPlugin-tomo/data
+      ignore_flats:
+        batch:
+          - start: 0
+            stop: 5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,11 @@ def i12_loader():
 
 
 @pytest.fixture
+def i12_loader_ignore_darks_flats():
+    return "samples/pipeline_template_examples/DLS/04_i12_ignore_darks_flats.yaml"
+
+
+@pytest.fixture
 def standard_loader():
     return "samples/loader_configs/standard_tomo.yaml"
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -83,6 +83,87 @@ def test_standard_tomo(standard_data, standard_data_path, standard_image_key_pat
     assert output.detector_x == 160  # detector_x
 
 
+def test_standard_tomo_ignore_darks(
+    standard_data, standard_data_path, standard_image_key_path
+):
+    preview = [None, None, None]
+    # Ignore 3 individual darks
+    ignore_darks = {"individual": [215, 217, 219]}
+    output = standard_tomo(
+        "tomo",
+        standard_data,
+        standard_data_path,
+        1,
+        preview,
+        1,
+        comm,
+        image_key_path=standard_image_key_path,
+        ignore_darks=ignore_darks,
+    )
+    assert output.darks.shape[0] == 17  # 3 darks removed
+    assert output.flats.shape[0] == 20  # no flats removed
+
+
+def test_standard_tomo_ignore_flats(
+    standard_data, standard_data_path, standard_image_key_path
+):
+    preview = [None, None, None]
+    # Ignore 5 batch flats
+    ignore_flats = {
+        "batch": [
+            {
+                "start": 185,
+                "stop": 189,
+            }
+        ]
+    }
+    output = standard_tomo(
+        "tomo",
+        standard_data,
+        standard_data_path,
+        1,
+        preview,
+        1,
+        comm,
+        image_key_path=standard_image_key_path,
+        ignore_flats=ignore_flats,
+    )
+    assert output.darks.shape[0] == 20  # no darks removed
+    assert output.flats.shape[0] == 15  # 5 flats removed
+
+
+def test_standard_tomo_ignore_flats_error(
+    standard_data, standard_data_path, standard_image_key_path
+):
+    preview = [None, None, None]
+    # Ignore 5 batch flats, one of which (the end one) is outside the range of
+    # flats
+    ignore_flats = {
+        "batch": [
+            {
+                "start": 195,
+                "stop": 200,
+            }
+        ]
+    }
+    expected_err_str = (
+        r"The flats indices to ignore are \[195, 196, 197, 198, 199, 200\], "
+        r"which has one or more values outside the flats in the dataset."
+    )
+    with pytest.raises(ValueError, match=expected_err_str):
+        output = standard_tomo(
+            "tomo",
+            standard_data,
+            standard_data_path,
+            1,
+            preview,
+            1,
+            comm,
+            image_key_path=standard_image_key_path,
+            ignore_flats=ignore_flats,
+        )
+
+
 def test_diad_loader():
     in_file = "tests/test_data/k11_diad/k11-18014.nxs"
     data_path = "/entry/imaging/data"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -285,6 +285,51 @@ def test_i12_testing_pipeline_output(
     assert "INFO | ~~~ Pipeline finished ~~~" in log_contents
 
 
+def test_i12_testing_ignore_darks_flats_pipeline_output(
+    cmd,
+    i12_data,
+    i12_loader_ignore_darks_flats,
+    testing_pipeline,
+    output_folder,
+    merge_yamls,
+):
+    cmd.insert(7, i12_data)
+    merge_yamls(i12_loader_ignore_darks_flats, testing_pipeline)
+    cmd.insert(8, "temp.yaml")
+    subprocess.check_output(cmd)
+
+    files = read_folder("output_dir/")
+    assert len(files) == 16
+
+    copied_yaml_path = list(filter(lambda x: ".yaml" in x, files)).pop()
+    assert compare_two_yamls("temp.yaml", copied_yaml_path)
+
+    log_files = list(filter(lambda x: ".log" in x, files))
+    assert len(log_files) == 1
+
+    tif_files = list(filter(lambda x: ".tif" in x, files))
+    assert len(tif_files) == 10
+
+    h5_files = list(filter(lambda x: ".h5" in x, files))
+    assert len(h5_files) == 4
+
+    log_contents = _get_log_contents(log_files[0])
+    assert "DEBUG | The full dataset shape is (724, 10, 192)" in log_contents
+    assert (
+        "DEBUG | Loading data: tests/test_data/i12/separate_flats_darks/i12_dynamic_start_stop180.nxs"
+        in log_contents
+    )
+    assert "DEBUG | Path to data: /1-TempPlugin-tomo/data" in log_contents
+    assert "DEBUG | Preview: (0:724, :, :)" in log_contents
+    assert "Saving intermediate file: 2-tomopy-normalize-tomo.h5" in log_contents
+    assert "Saving intermediate file: 3-tomopy-minus_log-tomo.h5" in log_contents
+    assert "Reslicing not necessary, as there is only one process" in log_contents
+    assert "Saving intermediate file: 4-tomopy-remove_stripe_fw-tomo.h5" in log_contents
+    assert "The center of rotation for 180 degrees sinogram is 95.5" in log_contents
+    assert "Saving intermediate file: 6-tomopy-recon-tomo-gridrec.h5" in log_contents
+    assert "INFO | ~~~ Pipeline finished ~~~" in log_contents
+
+
 def test_diad_testing_pipeline_output(
     cmd, diad_data, diad_loader, testing_pipeline, output_folder, merge_yamls
 ):


### PR DESCRIPTION
Fixes #157

Specifying individual indices of darks/flats is supported, as well as specifying a range of indices via start and stop values.

TODO list:
- [x] Add parameters for ignoring darks/flats
- [x] Add docs for the new loader parameters
- ~OPTIONAL: Move the parameters `ignore_darks` and `ignore_flats` to be within the existing `darks` and `flats` parameters~
- [x] Add pipeline test that ignores some darks and flats, ~which in turn influences the result of the processing (and thus can be verified numerically in the intermediate files)~
- [x] Add basic error checking that the provided darks/flats indices to ignore in the YAML are indeed referring to darks/flats
- [x] Add loader test to verify that the number of returned darks/flats reflects the number that should have been skipped