### PR TITLE
Add loader param for ignoring projections

### DIFF
--- a/docs/source/reference/loaders.rst
+++ b/docs/source/reference/loaders.rst
@@ -26,6 +26,10 @@ and to specify a range of indices to exclude, use the :code:`batch` subfield.
 These subfields can both be used at the same time to select batches of
 darks/flats/projections as well as individual darks/flats/projections to ignore.
 
+.. note:: The range provided to the :code:`batch` option via :code:`start` and
+          :code:`stop` is *inclusive*; ie, the :code:`stop` value is *included*
+          in the index values to ignore.
+
 It is also possible to ignore *all* darks and/or flats by setting the value of
 either :code:`ignore_darks` or :code:`ignore_flats` to :code:`true`. However,
 ignoring all *projections* is not yet supported.

--- a/docs/source/reference/loaders.rst
+++ b/docs/source/reference/loaders.rst
@@ -3,31 +3,55 @@
 HTTomo Loaders
 --------------
 
-Ignoring darks and/or flats
-===========================
+Ignoring darks, flats, or projections
+=====================================
 
-There are situations where certain dark or flat fields that have been collected
-in the data need to be excluded from processing. The standard tomography loader
-in HTTomo offers the functionality to exclude darks and/or flat field images
-based on their index in the dataset they are contained in. The images can be
-excluded by specifying either:
+There are situations where certain dark field, flat field, or projection images
+that have been collected in the data need to be excluded from processing. The
+standard tomography loader in HTTomo offers the functionality to exclude dark
+field, flat field, and projection images based on their index in the dataset
+they are contained in. The images can be excluded by specifying either:
 
 - Individual indices
 - A range of indices with start and stop values
 
-This functionality is used in a process list via the :code:`ignore_darks` and
-:code:`ignore_flats` parameters.
+This functionality is used in a process list via the :code:`ignore_darks`,
+:code:`ignore_flats`, and :code:`ignore_projections` parameters.
+
+Ignore modes
+============
 
 To specify individual indices to exclude, use the :code:`individual` subfield,
 and to specify a range of indices to exclude, use the :code:`batch` subfield.
 These subfields can both be used at the same time to select batches of
-darks/flats as well as individual darks/flats to ignore.
+darks/flats/projections as well as individual darks/flats/projections to ignore.
 
 It is also possible to ignore *all* darks and/or flats by setting the value of
-either :code:`ignore_darks` or :code:`ignore_flats` to :code:`true`.
+either :code:`ignore_darks` or :code:`ignore_flats` to :code:`true`. However,
+ignoring all *projections* is not yet supported.
 
-Below shows some example uses of the :code:`ignore_darks` parameter, and the
-:code:`ignore_flats` parameter can be used in a similar manner.
+The following is a summary of the supported modes of ignoring images for the
+cases of darks, flats, and projections:
+
+============ ========= ========= ===============
+Ignore mode  Darks     Flats     Projections
+============ ========= ========= ===============
+Individual   Supported Supported Supported
+Batch        Supported Supported Supported
+All          Supported Supported *Not supported*
+============ ========= ========= ===============
+
+.. note:: Ignoring projections is only supported when reading the data in as
+          projections; ie, when :code:`--dimension 1` is used when running
+          HTTomo (which is the default value when the flag is not explicitly
+          passed)
+
+Examples
+========
+
+Below are some example uses of the :code:`ignore_darks` parameter, and the
+:code:`ignore_flats` parameter can be used in a similar manner. The ignoring of
+individual and batch projections is the same as well.
 
 Ignore individual darks only
 ++++++++++++++++++++++++++++

--- a/httomo/data/hdf/_utils/load.py
+++ b/httomo/data/hdf/_utils/load.py
@@ -375,18 +375,18 @@ def get_angles(file: str, path: str, comm: MPI.Comm = MPI.COMM_WORLD) -> ndarray
     return angles
 
 
-def _parse_ignore_darks_flats(ignore: Dict) -> List[int]:
-    """Get all indices of darks/flats to ignore.
+def _parse_ignore_indices(ignore: Dict) -> List[int]:
+    """Get all indices to ignore.
 
     Parameters
     ----------
     ignore : Dict
-        A dict describing the individual and batch darks/flats to ignore.
+        A dict describing the individual and batch images to ignore.
 
     Returns
     -------
     List[int]
-        A list of indices that describe which darks/flats to ignore.
+        A list of indices that describe which images to ignore.
     """
     indices = []
     if "individual" in ignore.keys():
@@ -475,7 +475,7 @@ def get_darks_flats_together(
             if ignore_darks is True:
                 darks_indices = []
             elif isinstance(ignore_darks, dict):
-                ignore_darks_indices = _parse_ignore_darks_flats(ignore_darks)
+                ignore_darks_indices = _parse_ignore_indices(ignore_darks)
                 if not set(ignore_darks_indices) <= set(darks_indices):
                     err_str = (
                         f"The darks indices to ignore are "
@@ -488,7 +488,7 @@ def get_darks_flats_together(
             if ignore_flats is True:
                 flats_indices = []
             elif isinstance(ignore_flats, dict):
-                ignore_flats_indices = _parse_ignore_darks_flats(ignore_flats)
+                ignore_flats_indices = _parse_ignore_indices(ignore_flats)
                 if not set(ignore_flats_indices) <= set(flats_indices):
                     err_str = (
                         f"The flats indices to ignore are "
@@ -560,7 +560,7 @@ def get_darks_flats_separate(
         if ignore_indices is True:
             indices = []
         elif isinstance(ignore_indices, dict):
-            ignore_indices = _parse_ignore_darks_flats(ignore_indices)
+            ignore_indices = _parse_ignore_indices(ignore_indices)
             if not set(ignore_indices) <= set(indices):
                 err_str = (
                     f"The darks/flats indices to ignore are "

--- a/httomo/data/hdf/loaders.py
+++ b/httomo/data/hdf/loaders.py
@@ -38,6 +38,7 @@ def standard_tomo(
     flats: Optional[Dict] = None,
     ignore_darks: Optional[Union[bool, Dict]] = False,
     ignore_flats: Optional[Union[bool, Dict]] = False,
+    ignore_projections: Optional[Union[bool, Dict]] = False,
 ) -> LoaderData:
     """Loader for standard tomography data.
 
@@ -78,6 +79,9 @@ def standard_tomo(
     ignore_flats : optional, Union[bool, Dict]
         If bool, specifies ignoring all or none of flats. If dict, specifies
         individual and batch flats to ignore.
+    ignore_projections : optional, Union[bool, Dict]
+        If bool, specifies ignoring all or none of projections. If dict,
+        specifies individual and batch projections to ignore.
 
     Returns
     -------
@@ -138,6 +142,12 @@ def standard_tomo(
     data = load.load_data(
         str(in_file), dim, data_path, preview=preview_str, pad=pad_values, comm=comm
     )
+
+    # Remove projections (and associated angles) if specified
+    if ignore_projections is not False and isinstance(ignore_projections, dict):
+        data, angles = load.remove_projections(
+            data, angles, ignore_projections, data_indices[0], dimension, comm
+        )
 
     # Get darks and flats
     if darks is not None and flats is not None and darks["file"] != flats["file"]:

--- a/httomo/data/hdf/loaders.py
+++ b/httomo/data/hdf/loaders.py
@@ -148,6 +148,12 @@ def standard_tomo(
         err_str = "Ignoring all projections is not yet supported."
         raise ValueError(err_str)
     elif isinstance(ignore_projections, dict):
+        if dimension != 1:
+            err_str = (
+                "Ignoring projections is only supported when `--dimension 1` "
+                "is used (which is the default value)."
+            )
+            raise ValueError(err_str)
         data, angles = load.remove_projections(
             data, angles, ignore_projections, data_indices, dimension, comm
         )

--- a/httomo/data/hdf/loaders.py
+++ b/httomo/data/hdf/loaders.py
@@ -144,7 +144,10 @@ def standard_tomo(
     )
 
     # Remove projections (and associated angles) if specified
-    if ignore_projections is not False and isinstance(ignore_projections, dict):
+    if ignore_projections is True:
+        err_str = "Ignoring all projections is not yet supported."
+        raise ValueError(err_str)
+    elif isinstance(ignore_projections, dict):
         data, angles = load.remove_projections(
             data, angles, ignore_projections, data_indices, dimension, comm
         )

--- a/httomo/data/hdf/loaders.py
+++ b/httomo/data/hdf/loaders.py
@@ -146,7 +146,7 @@ def standard_tomo(
     # Remove projections (and associated angles) if specified
     if ignore_projections is not False and isinstance(ignore_projections, dict):
         data, angles = load.remove_projections(
-            data, angles, ignore_projections, data_indices[0], dimension, comm
+            data, angles, ignore_projections, data_indices, dimension, comm
         )
 
     # Get darks and flats

--- a/tests/test_chunk.py
+++ b/tests/test_chunk.py
@@ -1,0 +1,142 @@
+from typing import List, Tuple
+
+import pytest
+import numpy as np
+from unittest import mock
+
+from httomo.data.hdf._utils.chunk import get_data_bounds
+
+
+@pytest.mark.parametrize(
+    "nproc, data, allgather_return, expected_bounds",
+    [
+        # Case
+        # - 1 MPI process / serial run
+        # - remove no projections
+        (
+            1,
+            [np.empty((180, 128, 160))],
+            [(180, 128, 160)],
+            [(0, 180)],
+        ),
+        # Case
+        # - 2 MPI processes
+        # - remove no projections from either process
+        (
+            2,
+            [np.empty((90, 128, 160)), np.empty((90, 128, 160))],
+            [(90, 128, 160), (90, 128, 160)],
+            [(0, 90), (90, 180)],
+        ),
+        # Case
+        # - 2 MPI processes
+        # - remove 5 projections belonging to rank 0 process
+        (
+            2,
+            [np.empty((85, 128, 160)), np.empty((90, 128, 160))],
+            [(85, 128, 160), (90, 128, 160)],
+            [(0, 85), (85, 175)],
+        ),
+        # Case
+        # - 2 MPI processes
+        # - remove 5 projections belonging to rank 1 process
+        (
+            2,
+            [np.empty((90, 128, 160)), np.empty((85, 128, 160))],
+            [(90, 128, 160), (85, 128, 160)],
+            [(0, 90), (90, 175)],
+        ),
+        # Case
+        # - 4 MPI processes
+        # - remove no projections
+        (
+            4,
+            [
+                np.empty((45, 128, 160)),
+                np.empty((45, 128, 160)),
+                np.empty((45, 128, 160)),
+                np.empty((45, 128, 160)),
+            ],
+            [(45, 128, 160), (45, 128, 160), (45, 128, 160), (45, 128, 160)],
+            [(0, 45), (45, 90), (90, 135), (135, 180)],
+        ),
+        # Case
+        # - 4 MPI processes
+        # - remove 5 projections from rank 0 process
+        (
+            4,
+            [
+                np.empty((40, 128, 160)),
+                np.empty((45, 128, 160)),
+                np.empty((45, 128, 160)),
+                np.empty((45, 128, 160)),
+            ],
+            [(40, 128, 160), (45, 128, 160), (45, 128, 160), (45, 128, 160)],
+            [(0, 40), (40, 85), (85, 130), (130, 175)],
+        ),
+        # Case
+        # - 4 MPI processes
+        # - remove 5 projections from rank 2 process
+        (
+            4,
+            [
+                np.empty((45, 128, 160)),
+                np.empty((45, 128, 160)),
+                np.empty((40, 128, 160)),
+                np.empty((45, 128, 160)),
+            ],
+            [(45, 128, 160), (45, 128, 160), (40, 128, 160), (45, 128, 160)],
+            [(0, 45), (45, 90), (90, 130), (130, 175)],
+        ),
+        # Case
+        # - 4 MPI processes
+        # - remove 5 projections from rank 1 process
+        # - remove 5 projections from rank 3 process
+        (
+            4,
+            [
+                np.empty((45, 128, 160)),
+                np.empty((40, 128, 160)),
+                np.empty((45, 128, 160)),
+                np.empty((40, 128, 160)),
+            ],
+            [(45, 128, 160), (40, 128, 160), (45, 128, 160), (40, 128, 160)],
+            [(0, 45), (45, 85), (85, 130), (130, 170)],
+        ),
+    ],
+    # ID naming:
+    # {NO_OF_PROCS}-proc-{SLICE_DIM_LEN}-{PROC_0_LEN}-{PROC_1_LEN}-...
+    ids=[
+        "1-proc-180-180",
+        "2-proc-180-90-90",
+        "2-proc-180-85-90",
+        "2-proc-180-90-85",
+        "4-proc-180-45-45-45-45",
+        "4-proc-180-40-45-45-45",
+        "4-proc-180-45-45-40-45",
+        "4-proc-180-45-40-45-40",
+    ],
+)
+def test_get_data_bounds_projs(
+    nproc: int,
+    data: List[np.ndarray],
+    allgather_return: List[Tuple[int, int, int]],
+    expected_bounds: List[Tuple[int, int]],
+) -> None:
+    # Mock MPI communicator object
+    comm = mock.Mock()
+    # Mock the return of the `.allgather()` method on a communicator object
+    comm.allgather.return_value = allgather_return
+
+    # Fake each MPI process calling `get_data_bounds()` by running the function
+    # with a different data and rank
+    returned_bounds = []
+    for i in range(nproc):
+        comm.rank = i
+        bounds = get_data_bounds(data[i], comm, 0)
+        returned_bounds.append(bounds)
+
+    # Check that the bounds for each "process" matches the expected values
+    for i in range(nproc):
+        assert returned_bounds[i][0] == expected_bounds[i][0]
+        assert returned_bounds[i][1] == expected_bounds[i][1]


### PR DESCRIPTION
Fixes #161

Specifying a list of individual indices is supported, as well as a range of indices via start and stop values, similar to ignoring darks/flats.

TODO list:
- [x] Add parameter for ignoring projections
- [x] Add docs for new loader parameter
- [x] Add basic error checking that the provided projection indices to ignore in the YAML are indeed referring to projections
- [x] Add loader test to verify that the number of returned projections reflects the number that should have been skipped
- [x] OPTIONAL: Add test for `chunk.get_data_bounds()` to ensure data bounds get calculated correctly when running with multiple MPI processes (by mocking the return of `Comm.allgather()`)
- [ ] ~OPTIONAL: Implement for data that has been read as sinograms, and data that has been read along the third dimension~