### PR TITLE
Add pre-processing stage to pipeline

### DIFF
--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -11,6 +11,7 @@ import httomo.globals
 from httomo.logger import setup_logger
 from httomo.task_runner import run_tasks
 from httomo.yaml_checker import validate_yaml_config
+from httomo.yaml_loader import YamlLoader
 
 from . import __version__
 
@@ -34,7 +35,9 @@ def main():
 def check(yaml_config: Path, in_data: Path = None):
     """Check a YAML pipeline file for errors."""
     in_data = str(in_data) if isinstance(in_data, PurePath) else None
-    return validate_yaml_config(yaml_config, in_data)
+    YamlLoader.add_constructor("!Sweep", YamlLoader.sweep_manual)
+    YamlLoader.add_constructor("!SweepRange", YamlLoader.sweep_range)
+    return validate_yaml_config(yaml_config, YamlLoader, in_data)
 
 
 @main.command()

--- a/httomo/common.py
+++ b/httomo/common.py
@@ -168,6 +168,7 @@ class PreProcessInfo:
     """
     params: Dict[str, Any]
     method_name: str
+    module_path: str
     wrapper_func: Callable
 
 

--- a/httomo/common.py
+++ b/httomo/common.py
@@ -57,7 +57,6 @@ class MethodFunc:
     cpu: bool = True
     gpu: bool = False
     cupyrun: bool = False
-    is_loader: bool = False
     return_numpy: bool = False
     idx_global: int = 0
     global_statistics: bool = False

--- a/httomo/common.py
+++ b/httomo/common.py
@@ -158,3 +158,25 @@ class RunMethodInfo:
     package_name: str = None
     method_name: str = None
     global_statistics: bool = False
+
+
+@dataclass
+class PreProcessInfo:
+    """
+    Class holding execution info for each method in the pre-processing stage
+    of the pipeline
+    """
+    params: Dict[str, Any]
+    method_name: str
+    wrapper_func: Callable
+
+
+@dataclass
+class LoaderInfo:
+    """
+    Class holding execution info for the loader
+    """
+    params: Dict[str, Any]
+    method_name: str
+    method_func: Callable
+    pattern: Pattern

--- a/httomo/data/hdf/_utils/reslice.py
+++ b/httomo/data/hdf/_utils/reslice.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
+from mpi4py import MPI
 
 import numpy
 from mpi4py.MPI import Comm
@@ -142,7 +143,7 @@ def reslice_filebased(
 def single_sino_reslice(
     data: numpy.ndarray,
     idx: int,
-) -> numpy.ndarray:
+) -> Optional[numpy.ndarray]:
     if mpiutil.size == 1:
         log_once(
             "Reslicing for single sinogram not necessary, as there is only one process",
@@ -152,6 +153,9 @@ def single_sino_reslice(
         )
         return data[:, idx, :]
 
+    NUMPY_DTYPE = numpy.float32
+    MPI_DTYPE = MPI.FLOAT
+
     # Get shape of full/unsplit data, in order to define the shape of the numpy
     # array that will hold the gathered data
     data_shape = chunk.get_data_shape(data, 0)
@@ -159,15 +163,22 @@ def single_sino_reslice(
     if mpiutil.rank == 0:
         # Define the numpy array that will hold the single sinogram that has
         # been gathered from data from all MPI processes
-        recvbuf = numpy.empty((data_shape[0], data_shape[2]), dtype=numpy.uint16)
+        recvbuf = numpy.empty(data_shape[0]*data_shape[2], dtype=NUMPY_DTYPE)
     else:
         recvbuf = None
     # From the full projections that an MPI process has, send the data that
     # contributes to the sinogram at height `idx` (ie, send a "partial
     # sinogram")
-    sendbuf = numpy.ascontiguousarray(data[:, idx, :], dtype=numpy.uint16)
+    sendbuf = numpy.ascontiguousarray(
+        data[:, idx, :].reshape(data[:, idx, :].size), dtype=NUMPY_DTYPE
+    )
+    sizes_rec = mpiutil.comm.gather(sendbuf.size)
     # Gather the data into the rank 0 process
-    mpiutil.comm.Gather(sendbuf, recvbuf, root=0)
+    mpiutil.comm.Gatherv(
+        (sendbuf, data.shape[0]*data.shape[2], MPI_DTYPE),
+        (recvbuf, sizes_rec, MPI_DTYPE),
+        root=0
+    )
 
     if mpiutil.rank == 0:
-        return recvbuf
+        return recvbuf.reshape((data_shape[0], data_shape[2]))

--- a/httomo/pipeline_reader.py
+++ b/httomo/pipeline_reader.py
@@ -94,6 +94,7 @@ class PipelineReader:
             pre_process_infos.append(PreProcessInfo(
                 params=method_conf,
                 method_name=method_name,
+                module_path=module_name,
                 wrapper_func=wrapper_init_module.wrapper_method
             ))
 

--- a/httomo/pipeline_reader.py
+++ b/httomo/pipeline_reader.py
@@ -1,0 +1,159 @@
+import yaml
+from pathlib import Path
+from typing import Any, Dict, List, Protocol, TypeAlias
+from importlib import import_module
+
+from mpi4py import MPI
+
+from httomo.common import LoaderInfo, MethodFunc, PreProcessInfo
+from httomo.utils import Pattern, log_exception
+from httomo.wrappers_class import BackendWrapper
+from httomo.yaml_loader import YamlLoader
+
+
+MethodConfig: TypeAlias = Dict[str, Dict[str, Any]]
+PipelineStageConfig: TypeAlias = List[MethodConfig]
+PipelineConfig: TypeAlias = List[PipelineStageConfig]
+
+
+class PipelineReaderInterface(Protocol):
+    """
+    Functionalities that a pipeline YAML file reader should implement.
+    """
+    loader: type[YamlLoader]
+
+    def get_loader_info(self, filepath: Path, extra_params: Dict[str, Any]) -> LoaderInfo:
+        ...
+
+    def get_pre_process_info(self, filepath: Path, comm: MPI.Comm) -> List[PreProcessInfo]:
+        ...
+
+    def get_main_pipeline_info(self, filepath: Path, comm: MPI.Comm) -> List[MethodFunc]:
+        ...
+
+
+class PipelineReader:
+    """
+    Generate necessary objects for executing the loading, pre-processing, and
+    main processing stages of the pipeline.
+    """
+
+    def __init__(self, loader: type[YamlLoader]):
+        loader.add_constructor("!Sweep", loader.sweep_manual)
+        loader.add_constructor("!SweepRange", loader.sweep_range)
+        self.loader = loader
+
+
+    def get_loader_info(self, filepath: Path, extra_params: Dict[str, Any]) -> LoaderInfo:
+        loader_conf: MethodConfig = self.__parse_yaml(filepath)[0][0]
+        module_name, module_conf = loader_conf.popitem()
+        method_name, method_conf = module_conf.popitem()
+        module = import_module(module_name)
+        method_func = getattr(module, method_name)
+        method_conf.update(extra_params)
+        return LoaderInfo(
+            params=method_conf,
+            method_name=method_name,
+            method_func=method_func,
+            pattern=Pattern.all
+        )
+
+
+    def get_pre_process_info(
+            self,
+            filepath: Path,
+            comm: MPI.Comm
+        ) -> List[PreProcessInfo]:
+        pre_process_conf: PipelineStageConfig = self.__parse_yaml(filepath)[1]
+        pre_process_infos: List[PreProcessInfo] = []
+        PRE_PROCESS_METHODS = [
+            "remove_outlier3d",
+            "find_center_vo",
+            "find_center_360"
+        ]
+
+        for task_conf in pre_process_conf:
+            module_name, module_conf = task_conf.popitem()
+            split_module_name = module_name.split(".")
+            method_name, method_conf = module_conf.popitem()
+
+            if method_name not in PRE_PROCESS_METHODS:
+                err_str = f"Method {method_name} not allowed in pre-processing stage"
+                raise ValueError(err_str)
+
+            wrapper_init_module = BackendWrapper(
+                split_module_name[0],
+                split_module_name[1],
+                split_module_name[2],
+                method_name,
+                comm
+            )
+
+            pre_process_infos.append(PreProcessInfo(
+                params=method_conf,
+                method_name=method_name,
+                wrapper_func=wrapper_init_module.wrapper_method
+            ))
+
+        return pre_process_infos
+
+
+    def get_main_pipeline_info(
+            self,
+            filepath: Path,
+            comm: MPI.Comm
+        ) -> List[MethodFunc]:
+        conf: PipelineStageConfig = self.__parse_yaml(filepath)[2]
+        method_funcs: List[MethodFunc] = []
+
+        for i, task_conf in enumerate(conf):
+            module_name, module_conf = task_conf.popitem()
+            split_module_name = module_name.split(".")
+            method_name, method_conf = module_conf.popitem()
+            method_conf["method_name"] = method_name
+            method_conf.pop("data_in", None)
+            method_conf.pop("data_out", None)
+
+            if split_module_name[0] not in ["tomopy", "httomolib", "httomolibgpu"]:
+                err_str = (
+                    f"An unknown module name was encountered: " f"{split_module_name[0]}"
+                )
+                log_exception(err_str)
+                raise ValueError(err_str)
+
+            wrapper_init_module = BackendWrapper(
+                split_module_name[0],
+                split_module_name[1],
+                split_module_name[2],
+                method_name,
+                comm
+            )
+            wrapper_func = getattr(wrapper_init_module.module, method_name)
+            wrapper_method = wrapper_init_module.wrapper_method
+
+            method_funcs.append(
+                MethodFunc(
+                    module_name=module_name,
+                    method_func=wrapper_func,
+                    wrapper_func=wrapper_method,
+                    parameters=method_conf,
+                    cpu=True,
+                    gpu=False,
+                    cupyrun=False,
+                    calc_max_slices=None,
+                    output_dims_change=False,
+                    pattern=Pattern.all,
+                    return_numpy=False,
+                    idx_global=i+2,
+                    global_statistics=False,
+                )
+            )
+
+        return method_funcs
+
+
+    def __parse_yaml(self, filepath: Path) -> PipelineConfig:
+        with open(filepath, "r") as f:
+            yaml_conf = list(yaml.load_all(f, Loader=self.loader))
+        return yaml_conf
+

--- a/httomo/pipeline_reader.py
+++ b/httomo/pipeline_reader.py
@@ -51,6 +51,8 @@ class PipelineReader:
         module = import_module(module_name)
         method_func = getattr(module, method_name)
         method_conf.update(extra_params)
+        if "preview" not in method_conf.keys():
+            method_conf["preview"] = [None]
         return LoaderInfo(
             params=method_conf,
             method_name=method_name,

--- a/httomo/pipeline_reader.py
+++ b/httomo/pipeline_reader.py
@@ -57,7 +57,7 @@ class PipelineReader:
             params=method_conf,
             method_name=method_name,
             method_func=method_func,
-            pattern=Pattern.all
+            pattern=Pattern(extra_params["dimension"] - 1)
         )
 
 

--- a/httomo/pipeline_reader.py
+++ b/httomo/pipeline_reader.py
@@ -111,8 +111,6 @@ class PipelineReader:
             split_module_name = module_name.split(".")
             method_name, method_conf = module_conf.popitem()
             method_conf["method_name"] = method_name
-            method_conf.pop("data_in", None)
-            method_conf.pop("data_out", None)
 
             if split_module_name[0] not in ["tomopy", "httomolib", "httomolibgpu"]:
                 err_str = (

--- a/httomo/preprocess.py
+++ b/httomo/preprocess.py
@@ -59,6 +59,7 @@ def preprocess_data(
     else:
         res = None
 
+    res = comm.bcast(res, root=0)
     return res
 
 

--- a/httomo/preprocess.py
+++ b/httomo/preprocess.py
@@ -12,6 +12,7 @@ from numpy import newaxis
 
 from httomo.common import PreProcessInfo
 from httomo.data.hdf._utils.reslice import single_sino_reslice
+from httomo.methods_database.query import get_method_info
 
 
 Centering180Result: TypeAlias = float
@@ -24,12 +25,18 @@ def dezinging(
 ) -> np.ndarray[Any, np.dtype[np.float32]]:
 
     param_filter = ("method_name")
+    is_cupyrun = get_method_info(
+        preproc_info.module_path,
+        preproc_info.method_name,
+        "implementation"
+    ) == "gpu_cupy"
 
     return preproc_info.wrapper_func(
         preproc_info.method_name,
         {k:preproc_info.params[k] for k in preproc_info.params.keys() - param_filter},
         data,
         return_numpy=True,
+        cupyrun=is_cupyrun
     )
 
 
@@ -63,12 +70,18 @@ def centering(
         )
 
         param_filter = ("method_name", "data_in", "data_out", "ind")
+        is_cupyrun = get_method_info(
+            centering_method_info.module_path,
+            centering_method_info.method_name,
+            "implementation"
+        ) == "gpu_cupy"
         
         res = centering_method_info.wrapper_func(
             centering_method_info.method_name,
             {k:centering_method_info.params[k] for k in centering_method_info.params.keys() - param_filter},
             sino_slice,
             return_numpy=False,
+            cupyrun=is_cupyrun
         )
     else:
         res = None

--- a/httomo/preprocess.py
+++ b/httomo/preprocess.py
@@ -1,0 +1,79 @@
+"""
+Module contains pre-processing functions that are needed before the main 
+loop over GPU blocks has started. 
+
+For example: Centering, Dezingering for multidata, etc. 
+"""
+from collections.abc import Callable
+from inspect import signature
+from typing import Any, Dict, List, Tuple, Optional
+
+from mpi4py import MPI
+import numpy as np
+from numpy import ndarray
+
+from httomo.data.hdf._utils.reslice import single_sino_reslice
+from httomo.utils import (
+    Colour,
+    Pattern,
+    _get_slicing_dim,
+    log_exception,
+    log_once,
+    remove_ansi_escape_sequences,
+)
+
+def preprocess_data(
+    dict_preprocess: Dict[str, ndarray],
+    method_funcs: List[Tuple[List[str], object]],
+    dict_datasets_pipeline: Dict[str, Optional[ndarray]],
+    comm: MPI.Comm,
+) -> Dict:
+    """_summary_
+
+    Args:
+        dict_preprocess (Dict[str, ndarray]): _description_
+        method_funcs (List[Tuple[List[str], object]]): _description_
+        dict_datasets_pipeline (Dict[str, Optional[ndarray]]): _description_
+        comm (MPI.Comm): _description_
+
+    Returns:
+        Dict: _description_
+    """
+    if dict_preprocess['centering']:
+        # Finding the CoR is required before the main loop
+        if comm.rank == 0:
+            single_sino_start_time = MPI.Wtime()
+        
+        # get the slice index from the parameters list
+        slice_for_cor = method_funcs[dict_preprocess['center_method_indx']].parameters['ind']
+        if slice_for_cor == "mid" or slice_for_cor is None:
+            # local middle value to the preview index
+            slice_for_cor = dict_datasets_pipeline[method_funcs[0].parameters["name"]].shape[1] // 2 - 1
+        
+        # Gather a single sinogram to the rank 0 process
+        sino_slice = single_sino_reslice(dict_datasets_pipeline[method_funcs[0].parameters["name"]],
+                                         slice_for_cor)
+        
+        if comm.rank == 0:
+            # normalising the sinogram before calculating the CoR
+            if dict_datasets_pipeline["flats"] is not None:
+                flats1d = np.float32(np.mean(dict_datasets_pipeline["flats"][:,slice_for_cor,:],0))
+            else:
+                flats1d = 1.0
+            if dict_datasets_pipeline["darks"] is not None:
+                darks1d = np.float32(np.mean(dict_datasets_pipeline["darks"][:,slice_for_cor,:], 0))
+            else:
+                darks1d = 0.0
+            denom = flats1d - darks1d
+            denom[(np.where(denom == 0.0))] = 1.0 
+            sino_slice = sino_slice - darks1d / denom
+
+            import cupy as cp
+            mid_slice_gpu = cp.array(sino_slice, dtype=cp.float32)
+            from httomolibgpu.recon.rotation import find_center_vo
+            cor = find_center_vo(mid_slice_gpu)
+            single_sino_elapsed_time = MPI.Wtime() - single_sino_start_time
+            single_sino_end_str = f"~~~ Single sino reslice + GPU centering ~~~ took {single_sino_elapsed_time} sec to execute, CoR is {cor}"
+            log_once(single_sino_end_str, comm=comm, colour=Colour.BVIOLET)
+    
+    return 0

--- a/httomo/preprocess.py
+++ b/httomo/preprocess.py
@@ -10,7 +10,11 @@ from typing import Any, Dict, List, Tuple, Optional
 
 from mpi4py import MPI
 import numpy as np
-from numpy import ndarray
+from numpy import ndarray, newaxis
+
+from httomo.common import RunMethodInfo
+from httomo.postrun import postrun_method
+from httomo.prerun import prerun_method
 
 from httomo.data.hdf._utils.reslice import single_sino_reslice
 from httomo.utils import (
@@ -25,31 +29,33 @@ from httomo.utils import (
 def preprocess_data(
     dict_preprocess: Dict[str, ndarray],
     method_funcs: List[Tuple[List[str], object]],
+    misc_params: List[Tuple[List[str], object]],
     dict_datasets_pipeline: Dict[str, Optional[ndarray]],
     comm: MPI.Comm,
 ) -> Dict:
     """_summary_
 
     Args:
-        dict_preprocess (Dict[str, ndarray]): _description_
-        method_funcs (List[Tuple[List[str], object]]): _description_
-        dict_datasets_pipeline (Dict[str, Optional[ndarray]]): _description_
-        comm (MPI.Comm): _description_
+        dict_preprocess (Dict[str, ndarray]): a dictionary with parameters relevant to pre-process methods
+        method_funcs (List[Tuple[List[str], object]]): list of method functions
+        dict_datasets_pipeline (Dict[str, Optional[ndarray]]): dictionary with parameters
+        comm (MPI.Comm): comm
 
     Returns:
-        Dict: _description_
+        Dict: dictionary with parameters
     """
     if dict_preprocess['centering']:
         # Finding the CoR is required before the main loop
-        if comm.rank == 0:
-            single_sino_start_time = MPI.Wtime()
-        
+        #if comm.rank == 0:
+        #    single_sino_start_time = MPI.Wtime()        
+        current_func = method_funcs[dict_preprocess['center_method_indx']]
         # get the slice index from the parameters list
-        slice_for_cor = method_funcs[dict_preprocess['center_method_indx']].parameters['ind']
+        slice_for_cor = current_func.parameters['ind']
         if slice_for_cor == "mid" or slice_for_cor is None:
             # local middle value to the preview index
             slice_for_cor = dict_datasets_pipeline[method_funcs[0].parameters["name"]].shape[1] // 2 - 1
         
+        current_func.parameters['ind'] = 0
         # Gather a single sinogram to the rank 0 process
         sino_slice = single_sino_reslice(dict_datasets_pipeline[method_funcs[0].parameters["name"]],
                                          slice_for_cor)
@@ -66,14 +72,55 @@ def preprocess_data(
                 darks1d = 0.0
             denom = flats1d - darks1d
             denom[(np.where(denom == 0.0))] = 1.0 
-            sino_slice = sino_slice - darks1d / denom
-
-            import cupy as cp
-            mid_slice_gpu = cp.array(sino_slice, dtype=cp.float32)
-            from httomolibgpu.recon.rotation import find_center_vo
-            cor = find_center_vo(mid_slice_gpu)
-            single_sino_elapsed_time = MPI.Wtime() - single_sino_start_time
-            single_sino_end_str = f"~~~ Single sino reslice + GPU centering ~~~ took {single_sino_elapsed_time} sec to execute, CoR is {cor}"
-            log_once(single_sino_end_str, comm=comm, colour=Colour.BVIOLET)
+            data = sino_slice - darks1d / denom                      
+            
+            data = data[:, newaxis, :] # increase dim     
+            
+            #single_sino_elapsed_time = MPI.Wtime() - single_sino_start_time
+            #single_sino_end_str = f"~~~ Single sino reslice + GPU centering ~~~ took {single_sino_elapsed_time} sec to execute, CoR is {cor}"
+            #log_once(single_sino_end_str, comm=comm, colour=Colour.BVIOLET)
     
-    return 0
+    if comm.rank == 0:
+        # preparing everything for the wrapper execution
+        module_path = current_func.module_name
+        method_name = current_func.method_func.__name__
+        func_wrapper = current_func.wrapper_func
+        package_name = current_func.module_name.split(".")[0]
+        
+        #: create an object that would be passed along to prerun_method,
+        #: run_method, and postrun_method
+        run_method_info = RunMethodInfo(task_idx=dict_preprocess['center_method_indx'])
+        
+        #: prerun - before running the method, update the dictionaries
+        prerun_method(
+            run_method_info,
+            False,
+            misc_params,
+            current_func,
+            dict_datasets_pipeline,
+        )
+        
+        # Assign the `data` parameter of the method to the prepared data array
+        run_method_info.dict_httomo_params["data"] = data
+        
+        # remove methods name from the parameters list of a method
+        run_method_info.dict_params_method.pop('method_name')
+        
+        # run the wrapper
+        res = func_wrapper(
+            method_name,
+            run_method_info.dict_params_method,
+            **run_method_info.dict_httomo_params,
+        )
+        
+        # Store the output(s) of the method in the appropriate
+        # dataset in the `dict_datasets_pipeline` dict
+        if isinstance(res, (tuple, list)):
+            # The method produced multiple outputs
+            for val, dataset in zip(res, run_method_info.data_out):
+                dict_datasets_pipeline[dataset] = val
+        else:
+            # The method produced a single output
+            dict_datasets_pipeline[run_method_info.data_out] = res   
+            
+    return dict_datasets_pipeline

--- a/httomo/preprocess.py
+++ b/httomo/preprocess.py
@@ -4,123 +4,91 @@ loop over GPU blocks has started.
 
 For example: Centering, Dezingering for multidata, etc. 
 """
-from collections.abc import Callable
-from inspect import signature
-from typing import Any, Dict, List, Tuple, Optional
+from typing import Tuple, Union
 
 from mpi4py import MPI
 import numpy as np
-from numpy import ndarray, newaxis
+from numpy import newaxis
 
-from httomo.common import RunMethodInfo
-from httomo.postrun import postrun_method
-from httomo.prerun import prerun_method
-
+from httomo.common import MethodFunc
 from httomo.data.hdf._utils.reslice import single_sino_reslice
-from httomo.utils import (
-    Colour,
-    Pattern,
-    _get_slicing_dim,
-    log_exception,
-    log_once,
-    remove_ansi_escape_sequences,
-)
 
 def preprocess_data(
-    dict_preprocess: Dict[str, ndarray],
-    method_funcs: List[Tuple[List[str], object]],
-    misc_params: List[Tuple[List[str], object]],
-    dict_datasets_pipeline: Dict[str, Optional[ndarray]],
+    projs: np.ndarray,
+    darks: np.ndarray,
+    flats: np.ndarray,
+    centering_method_func: MethodFunc,
     comm: MPI.Comm,
-) -> Dict:
+) -> Union[float, Tuple[float, float, float, float]]:
     """_summary_
 
     Args:
-        dict_preprocess (Dict[str, ndarray]): a dictionary with parameters relevant to pre-process methods
-        method_funcs (List[Tuple[List[str], object]]): list of method functions
-        dict_datasets_pipeline (Dict[str, Optional[ndarray]]): dictionary with parameters
-        comm (MPI.Comm): comm
+        projs: np.ndarray: projection data
+        darks: np.ndarray: dark-field data
+        flats: np.ndarray: flat-field data
+        centering_method_func MethodFunc: object representing centering method
+        comm (MPI.Comm): communicator object
 
     Returns:
-        Dict: dictionary with parameters
+        Union[float, Tuple[float, float, float, float]]: result from regular
+            centering, or 360 centering
     """
-    if dict_preprocess['centering']:
-        # Finding the CoR is required before the main loop
-        #if comm.rank == 0:
-        #    single_sino_start_time = MPI.Wtime()        
-        current_func = method_funcs[dict_preprocess['center_method_indx']]
-        # get the slice index from the parameters list
-        slice_for_cor = current_func.parameters['ind']
-        if slice_for_cor == "mid" or slice_for_cor is None:
-            # local middle value to the preview index
-            slice_for_cor = dict_datasets_pipeline[method_funcs[0].parameters["name"]].shape[1] // 2 - 1
-        
-        current_func.parameters['ind'] = 0
-        # Gather a single sinogram to the rank 0 process
-        sino_slice = single_sino_reslice(dict_datasets_pipeline[method_funcs[0].parameters["name"]],
-                                         slice_for_cor)
-        
-        if comm.rank == 0:
-            # normalising the sinogram before calculating the CoR
-            if dict_datasets_pipeline["flats"] is not None:
-                flats1d = np.float32(np.mean(dict_datasets_pipeline["flats"][:,slice_for_cor,:],0))
-            else:
-                flats1d = 1.0
-            if dict_datasets_pipeline["darks"] is not None:
-                darks1d = np.float32(np.mean(dict_datasets_pipeline["darks"][:,slice_for_cor,:], 0))
-            else:
-                darks1d = 0.0
-            denom = flats1d - darks1d
-            denom[(np.where(denom == 0.0))] = 1.0 
-            data = sino_slice - darks1d / denom                      
-            
-            data = data[:, newaxis, :] # increase dim     
-            
-            #single_sino_elapsed_time = MPI.Wtime() - single_sino_start_time
-            #single_sino_end_str = f"~~~ Single sino reslice + GPU centering ~~~ took {single_sino_elapsed_time} sec to execute, CoR is {cor}"
-            #log_once(single_sino_end_str, comm=comm, colour=Colour.BVIOLET)
-    
+    sino_slice, slice_for_cor = get_sino(projs, centering_method_func.parameters['ind'])
+
     if comm.rank == 0:
-        # preparing everything for the wrapper execution
-        module_path = current_func.module_name
-        method_name = current_func.method_func.__name__
-        func_wrapper = current_func.wrapper_func
-        package_name = current_func.module_name.split(".")[0]
-        
-        #: create an object that would be passed along to prerun_method,
-        #: run_method, and postrun_method
-        run_method_info = RunMethodInfo(task_idx=dict_preprocess['center_method_indx'])
-        
-        #: prerun - before running the method, update the dictionaries
-        prerun_method(
-            run_method_info,
-            False,
-            misc_params,
-            current_func,
-            dict_datasets_pipeline,
+        sino_slice = normalise_sino(
+            sino_slice,
+            flats[:,slice_for_cor,:],
+            darks[:,slice_for_cor,:],
         )
-        
-        # Assign the `data` parameter of the method to the prepared data array
-        run_method_info.dict_httomo_params["data"] = data
-        
-        # remove methods name from the parameters list of a method
-        run_method_info.dict_params_method.pop('method_name')
+
+        # preparing everything for the wrapper execution
+        method_name = centering_method_func.parameters.pop("method_name")
+        func_wrapper = centering_method_func.wrapper_func
+        del centering_method_func.parameters["data_in"]
+        del centering_method_func.parameters["data_out"]
+        del centering_method_func.parameters["ind"]
         
         # run the wrapper
         res = func_wrapper(
             method_name,
-            run_method_info.dict_params_method,
-            **run_method_info.dict_httomo_params,
+            centering_method_func.parameters,
+            sino_slice,
+            return_numpy=False,
         )
-        
-        # Store the output(s) of the method in the appropriate
-        # dataset in the `dict_datasets_pipeline` dict
-        if isinstance(res, (tuple, list)):
-            # The method produced multiple outputs
-            for val, dataset in zip(res, run_method_info.data_out):
-                dict_datasets_pipeline[dataset] = val
-        else:
-            # The method produced a single output
-            dict_datasets_pipeline[run_method_info.data_out] = res   
-            
-    return dict_datasets_pipeline
+    else:
+        res = None
+
+    return res
+
+
+def get_sino(
+    data: np.ndarray,
+    idx: str,
+) -> Tuple[np.ndarray, int]:
+    if idx == "mid" or idx is None:
+        # local middle value to the preview index
+        slice_for_cor = data.shape[1] // 2 - 1
+
+    # Gather a single sinogram to the rank 0 process
+    sino_slice = single_sino_reslice(data, slice_for_cor)
+    return sino_slice, slice_for_cor
+
+
+def normalise_sino(
+    sino: np.ndarray,
+    flats: np.ndarray,
+    darks: np.ndarray,
+) -> np.ndarray:
+    if flats is not None:
+        flats1d = np.float32(np.mean(flats, 0))
+    else:
+        flats1d = 1.0
+    if darks is not None:
+        darks1d = np.float32(np.mean(darks))
+    else:
+        darks1d = 0.0
+    denom = flats1d - darks1d
+    denom[(np.where(denom == 0.0))] = 1.0
+    sino -= darks1d / denom
+    return sino[:, newaxis, :] # increase dim

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import cupy as cp
 from httomolib.misc.images import save_to_images
 from mpi4py import MPI
 from numpy import ndarray

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -120,7 +120,7 @@ def run_tasks(
          method_funcs[i] = _assign_attribute_to_method(method_func, "memory_gpu")
 
     # Initialising platform sections (skipping loader)
-    platform_sections = _determine_platform_sections(method_funcs[1:], save_all)    
+    platform_sections = _determine_platform_sections(method_funcs, save_all)
 
     # Check pipeline for the number of parameter sweeps present. If one is
     # defined, raise an error, due to not supporting parameter sweeps in a

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -212,11 +212,25 @@ def run_tasks(
 
     # Execute pre-processing of data if needed. For instance, we might
     # want to dezinger data but also flats and darks in the loop
-    preprocess_data(dict_preprocess,
-                    method_funcs,
-                    possible_extra_params,
-                    dict_datasets_pipeline,
-                    comm)
+    centering_method_func = method_funcs[dict_preprocess["center_method_indx"]]
+    centering_out_name = centering_method_func.parameters["data_out"]
+    res = preprocess_data(
+        dict_datasets_pipeline[method_funcs[0].parameters["name"]],
+        dict_datasets_pipeline["darks"],
+        dict_datasets_pipeline["flats"],
+        centering_method_func,
+        comm
+    )
+
+    # Store the output(s) of the method in the appropriate
+    # dataset in the `dict_datasets_pipeline` dict
+    if isinstance(res, (tuple, list)):
+        # The method produced multiple outputs
+        for val, dataset in zip(res, centering_out_name):
+            dict_datasets_pipeline[dataset] = val
+    else:
+        # The method produced a single output
+        dict_datasets_pipeline[centering_out_name] = res
     
     # data shape and dtype are useful when calculating max slices
     data_shape = dict_datasets_pipeline[method_funcs[0].parameters["name"]].shape

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -205,6 +205,8 @@ def run_tasks(
             dezinging_preproc_idx = i
 
     if dezinging_preproc_idx is not None:
+        dezing_preproc_str = f"Running pre-processing: {pre_process_infos[dezinging_preproc_idx].method_name}"
+        log_once(dezing_preproc_str, comm=comm, colour=Colour.BLUE, level=0)
         dict_datasets_pipeline[loader_run_info.params["name"]] = \
             httomo.preprocess.dezinging(
                 dict_datasets_pipeline[loader_run_info.params["name"]],
@@ -221,6 +223,8 @@ def run_tasks(
                 pre_process_infos[dezinging_preproc_idx]
             )
 
+    centering_preproc_str = f"Running pre-processing: {pre_process_infos[centering_preproc_idx].method_name}"
+    log_once(centering_preproc_str, comm=comm, colour=Colour.BLUE, level=0)
     cor = httomo.preprocess.centering(
         dict_datasets_pipeline[loader_run_info.params["name"]],
         dict_datasets_pipeline["darks"],

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -149,11 +149,6 @@ def run_tasks(
         colour=Colour.CYAN,
         level=0,
     )
-
-    # Check if a value for the `preview` parameter of the loader has
-    # been provided
-    if "preview" not in method_funcs[0].parameters.keys():
-        method_funcs[0].parameters["preview"] = [None]
     
     output_colour_list = [Colour.GREEN, Colour.CYAN, Colour.GREEN]
     output_colour_list_short = [Colour.GREEN, Colour.CYAN]

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -240,14 +240,14 @@ def run_tasks(
         dict_datasets_pipeline[centering_out_name] = cor
     
     # data shape and dtype are useful when calculating max slices
-    data_shape = dict_datasets_pipeline[method_funcs[0].parameters["name"]].shape
+    data_shape = dict_datasets_pipeline[loader_run_info.params["name"]].shape
     # data_dtype = loader_info.data.dtype
     data_dtype = np.dtype(np.float32) # make the data type constant for the run
     
     ##---------- MAIN LOOP STARTS HERE ------------##
     idx = 0
     # initialise the CPU data array with the loaded data, we override it at the end of every section
-    data_full_section = dict_datasets_pipeline[method_funcs[idx].parameters["name"]]
+    data_full_section = dict_datasets_pipeline[loader_run_info.params["name"]]
     for i, section in enumerate(platform_sections):  
         # getting the slicing dimension of the section
         slicing_dim_section = _get_slicing_dim(section.pattern) - 1        
@@ -465,7 +465,7 @@ def run_tasks(
         # `dict_datasets_pipeline`
         # - the `data_full_section` variable
         if contains_recon:
-            dict_datasets_pipeline[method_funcs[0].parameters["name"]] = \
+            dict_datasets_pipeline[loader_run_info.params["name"]] = \
                 recon_arr
             data_full_section = recon_arr
         

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -198,13 +198,6 @@ def run_tasks(
     del loader_info.darks
     del loader_info.flats
 
-    # Execute pre-processing of data if needed. For instance, we might
-    # want to calculate CoR before the data has been modified
-    temp_dict = preprocess_data(dict_preprocess,
-                                method_funcs,
-                                dict_datasets_pipeline,
-                                comm)
-
     # Extra params relevant to httomo that a wrapper function might need
     possible_extra_params = [
         (["darks"], dict_datasets_pipeline["darks"]),
@@ -215,8 +208,16 @@ def run_tasks(
         (["return_numpy"], False),
         (["cupyrun"], False),
         (["save_result"], False),
-    ]
+    ]  
 
+    # Execute pre-processing of data if needed. For instance, we might
+    # want to dezinger data but also flats and darks in the loop
+    preprocess_data(dict_preprocess,
+                    method_funcs,
+                    possible_extra_params,
+                    dict_datasets_pipeline,
+                    comm)
+    
     # data shape and dtype are useful when calculating max slices
     data_shape = dict_datasets_pipeline[method_funcs[0].parameters["name"]].shape
     # data_dtype = loader_info.data.dtype

--- a/httomo/task_runner.py
+++ b/httomo/task_runner.py
@@ -22,7 +22,7 @@ import httomo.globals
 from httomo._stats.globals import min_max_mean_std
 from httomo.common import MethodFunc, PlatformSection, ResliceInfo, RunMethodInfo
 from httomo.data.hdf._utils.chunk import get_data_shape, save_dataset
-from httomo.data.hdf._utils.reslice import reslice, reslice_filebased
+from httomo.data.hdf._utils.reslice import reslice, reslice_filebased, single_sino_reslice
 from httomo.data.hdf._utils.save import intermediate_dataset
 from httomo.data.hdf.loaders import LoaderData
 from httomo.methods_database.query import get_method_info
@@ -165,6 +165,13 @@ def run_tasks(
     loader_func = method_funcs[0].method_func
     # collect meta data from LoaderData.
     loader_info = loader_func(**method_funcs[0].parameters)
+
+    # Gather a single sinogram (the middle one) to the rank 0 process
+    #
+    # TODO: Hardcoding the mid slice for now, later it needs to be properly
+    # calculated
+    MID_SLICE_IDX = 1080
+    mid_slice = single_sino_reslice(loader_info.data, MID_SLICE_IDX)
 
     output_str_list = [
         f"    Finished task 1 (pattern={method_funcs[0].pattern.name}): {loader_method_name} (",

--- a/httomo/wrappers_class.py
+++ b/httomo/wrappers_class.py
@@ -215,8 +215,8 @@ class BaseWrapper:
         overlap_position = 0
 
         if method_name == "find_center_360":
-            (rot_center, overlap, side, overlap_position) = self.comm.bcast(
-                (rot_center, overlap, side, overlap_position), root=self.comm.rank
+            (rot_center, overlap, side, overlap_position) = method_func(
+                data, **dict_params_method
             )
             log_once(
                 f"###___The center of rotation for 360 degrees sinogram is {rot_center},"
@@ -227,7 +227,7 @@ class BaseWrapper:
             )
             return (rot_center, overlap, side, overlap_position)
         elif method_name == "find_center_vo":
-            rot_center = self.comm.bcast(rot_center, root=self.comm.rank)
+            rot_center = method_func(data, **dict_params_method)
             log_once(
                     f"###____The center of rotation for 180 degrees sinogram is {rot_center}____###",
                     comm=self.comm,

--- a/httomo/wrappers_class.py
+++ b/httomo/wrappers_class.py
@@ -213,9 +213,10 @@ class BaseWrapper:
         overlap = 0
         side = 0
         overlap_position = 0
+
         if method_name == "find_center_360":
-            (rot_center, overlap, side, overlap_position) = method_func(
-                data, **dict_params_method
+            (rot_center, overlap, side, overlap_position) = self.comm.bcast(
+                (rot_center, overlap, side, overlap_position), root=self.comm.rank
             )
             log_once(
                 f"###___The center of rotation for 360 degrees sinogram is {rot_center},"
@@ -226,7 +227,7 @@ class BaseWrapper:
             )
             return (rot_center, overlap, side, overlap_position)
         elif method_name == "find_center_vo":
-            rot_center = method_func(data, **dict_params_method)
+            rot_center = self.comm.bcast(rot_center, root=self.comm.rank)
             log_once(
                     f"###____The center of rotation for 180 degrees sinogram is {rot_center}____###",
                     comm=self.comm,
@@ -275,6 +276,7 @@ class BaseWrapper:
                 data, out_dir, comm_rank=comm.rank, **dict_params_method
             )
         return None
+
 
 class BackendWrapper(BaseWrapper):
     """A class that wraps backend functions for httomo"""

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -152,10 +152,8 @@ def check_one_method_per_module(
         "\nDoing a sanity check first...",
         colour=Colour.GREEN,
     )
-    sanity_check(yaml_file, loader)
-    check_all_stages_defined(yaml_file, loader)
-    check_all_stages_non_empty(yaml_file, loader)
-    yaml_data = check_loading_stage_one_method(yaml_file, loader)
+    with open(yaml_file, "r") as f:
+        yaml_data = list(yaml.load_all(f, Loader=loader))
 
     for stage in yaml_data:
         lvalues = [value for d in stage for value in d.values()]
@@ -170,7 +168,7 @@ def check_one_method_per_module(
                 return False
 
     _print_with_colour(
-        "'One method per module' check was also successfully done...\n",
+        "'One method per module' check was successfully done...\n",
         colour=Colour.GREEN,
     )
     return yaml_data

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -2,12 +2,14 @@
 Module for checking the validity of yaml files.
 """
 import os
-from typing import Any
+from typing import Any, Optional
 
 import h5py
 import yaml
 
+from httomo.pipeline_reader import PipelineConfig
 from httomo.utils import Colour
+from httomo.yaml_loader import YamlLoader
 from httomo.yaml_utils import get_external_package_current_version
 
 __all__ = [
@@ -57,6 +59,30 @@ def sanity_check(yaml_file):
                     f"Error in the YAML_CONFIG file at line {e.problem_mark.line}. "
                     "Please recheck the file."
                 )
+
+
+def check_all_stages_defined(
+        yaml_file: str,
+        loader: type[YamlLoader]
+) -> Optional[PipelineConfig]:
+    """
+    Check if all three stages are defined in the YAML (loading, pre-processing,
+    main processing).
+    """
+    with open(yaml_file, "r") as f:
+        yaml_data = list(yaml.load_all(f, Loader=loader))
+
+    assert isinstance(yaml_data, list)
+    if len(yaml_data) != 3:
+        _print_with_colour(
+            "Please make sure to define the three stages in the pipeline YAML "
+            "file:\n"
+            "1) loading\n"
+            "2) pre-processing\n"
+            "3) main processing\n"
+        )
+        return
+    return yaml_data
 
 
 def check_one_method_per_module(yaml_file):

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -115,6 +115,29 @@ def check_loading_stage_one_method(conf: PipelineConfig) -> bool:
     return True
 
 
+def check_first_stage_has_loader(conf: PipelineConfig) -> bool:
+    """
+    Check that the only method in the first stage in the pipeline YAML is a
+    loader.
+    """
+    first_stage_method = conf[0][0]
+    module_name = list(first_stage_method.keys())[0]
+
+    _print_with_colour(
+        "Checking that the first method in the pipeline is a loader...",
+        colour=Colour.GREEN,
+    )
+    if module_name != "httomo.data.hdf.loaders":
+        _print_with_colour(
+            "The first method in the YAML_CONFIG file is not a loader from "
+            "'httomo.data.hdf.loaders'. Please recheck the yaml file."
+        )
+        return False
+    _print_with_colour("Loader check successful!!\n", colour=Colour.GREEN)
+
+    return True
+
+
 def check_one_method_per_module(conf: PipelineConfig) -> bool:
     """
     Check that we cannot have a yaml file with more than one method

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -347,124 +347,44 @@ def _store_hdf5_members(group, members_list, path=""):
             members_list.append((new_path, value))
 
 
-def validate_yaml_config(yaml_file, in_file: str = None) -> bool:
+def validate_yaml_config(
+        yaml_file: str,
+        loader: type[YamlLoader],
+        in_file: Optional[str] = None
+) -> bool:
     """
     Check that the modules, methods, and parameters in the `YAML_CONFIG` file
     are valid, and adhere to the same structure as in each corresponding
     module in `httomo.templates`.
     """
-    yaml_data = check_one_method_per_module(yaml_file)
-
-    modules = [next(iter(d)) for d in yaml_data]
-    methods = [next(iter(d.values())) for d in yaml_data]
-    packages = [
-        m.split(".")[0] + "/" + get_external_package_current_version(m.split(".")[0])
-        if m.split(".")[0] != "httomo"
-        else m.split(".")[0]
-        for m in modules
-    ]
-
-    #: the first method is always a loader
-    #: so `testing_pipeline.yaml` should not pass.
-    _print_with_colour(
-        "Checking that the first method in the pipeline is a loader...",
-        colour=Colour.GREEN,
-    )
-    if modules[0] != "httomo.data.hdf.loaders":
-        _print_with_colour(
-            "The first method in the YAML_CONFIG file is not a loader from "
-            "'httomo.data.hdf.loaders'. Please recheck the yaml file."
-        )
-        return False
-    _print_with_colour("Loader check successful!!\n", colour=Colour.GREEN)
-
-    if in_file is not None:
-        with h5py.File(in_file, "r") as f:
-            hdf5_members = []
-            _store_hdf5_members(f, hdf5_members)
-            hdf5_members = [m[0] for m in hdf5_members]
-
-        _print_with_colour(
-            "Checking that the paths to the data and keys in the YAML_CONFIG file "
-            "match the paths and keys in the input file (IN_DATA)...",
-            colour=Colour.GREEN,
-        )
-        loader_params = next(iter(methods[0].values()))
-        _path_keys = [key for key in loader_params if "_path" in key]
-        for key in _path_keys:
-            if loader_params[key].strip("/") not in hdf5_members:
-                _print_with_colour(
-                    f"'{loader_params[key]}' is not a valid path to a dataset in YAML_CONFIG. "
-                    "Please recheck the yaml file."
-                )
-                return False
-        _print_with_colour("Loader paths check successful!!\n", colour=Colour.GREEN)
-
-    parent_dir = os.path.dirname(os.path.abspath("__file__"))
-    templates_dir = os.path.join(parent_dir, "templates")
-    assert os.path.exists(templates_dir)
-
-    _template_yaml_files = [
-        os.path.join(
-            templates_dir, packages[i], modules[i], next(iter(methods[i])) + ".yaml"
-        )
-        for i in range(len(modules))
-    ]
-
-    for i, f in enumerate(_template_yaml_files):
-        if not os.path.exists(f):
-            _print_with_colour(
-                f"'{modules[i] + '/' + next(iter(methods[i]))}' is not a valid"
-                " path to a method. Please recheck the yaml file."
-            )
+    with open(yaml_file, "r") as f:
+        conf_generator: Generator = yaml.load_all(f, Loader=loader)
+        if not sanity_check(conf_generator):
             return False
 
-    _template_yaml_data_list = [
-        next(iter(d.values()))
-        for f in _template_yaml_files
-        for d in open_yaml_config(f)
-    ]
+    with open(yaml_file, "r") as f:
+        conf = list(yaml.load_all(f, Loader=loader))
+    if not check_all_stages_defined(conf):
+        return False
+    if not check_all_stages_non_empty(conf):
+        return False
+    if not check_loading_stage_one_method(conf):
+        return False
+    if not check_first_stage_has_loader(conf):
+        return False
+    if not check_one_method_per_module(conf):
+        return False
+    if in_file is not None:
+        if not check_hdf5_paths_against_loader(conf[0][0], in_file):
+            return False
+    if not check_methods_exist_in_templates(conf):
+        return False
+    if not check_valid_method_parameters(conf, loader):
+        return False
 
-    for i, _ in enumerate(modules):
-        end_str_list = ["Checking '", next(iter(methods[i])), "' and its parameters..."]
-        colours = [Colour.GREEN, Colour.CYAN, Colour.GREEN]
-        _print_with_colour(end_str_list, colours)
-        d1 = methods[i]
-        d2 = _template_yaml_data_list[i]
-
-        for key in d1.keys():
-            for parameter in d1[key].keys():
-                assert isinstance(parameter, str)
-
-                if parameter not in d2[key].keys():
-                    _print_with_colour(
-                        f"Parameter '{parameter}' in the '{modules[i]}' method is not valid."
-                    )
-                    return False
-
-                # there should be no REQUIRED parameters in the YAML_CONFIG file
-                if d1[key][parameter] == "REQUIRED":
-                    _print_with_colour(
-                        f"A value is needed for the parameter '{parameter}' in the '{modules[i]}' method."
-                        " Please specify a value instead of 'REQUIRED'."
-                        " Refer to the method docstring for more information."
-                    )
-                    return False
-
-                # skip tuples for !Sweep and !SweepRange
-                if isinstance(d1[key][parameter], tuple) or None in (
-                    d1[key][parameter],
-                    d2[key][parameter],
-                ):
-                    continue
-
-                if not isinstance(d1[key][parameter], type(d2[key][parameter])):
-                    _print_with_colour(
-                        f"Value assigned to parameter '{parameter}' in the '{next(iter(methods[i]))}' method"
-                        f" is not correct. It should be of type {type(d2[key][parameter])}."
-                    )
-                    return False
-
-    end_str = "\nYAML validation successful!! Please feel free to use the `run` command to run the pipeline."
+    end_str = (
+        "\nYAML validation successful!! Please feel free to use the `run` "
+        "command to run the pipeline."
+    )
     _print_with_colour(end_str, colour=Colour.BVIOLET)
     return True

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -19,7 +19,10 @@ __all__ = [
 ]
 
 
-def sanity_check(yaml_file):
+def sanity_check(
+        yaml_file: str,
+        loader: type[YamlLoader]
+) -> Optional[PipelineConfig]:
     """
     Check if the yaml file is properly indented, has valid mapping and tags.
     """
@@ -27,38 +30,39 @@ def sanity_check(yaml_file):
         "Checking that the YAML_CONFIG is properly indented and has valid mappings and tags...",
         colour=Colour.GREEN,
     )
-    with open(yaml_file, "r") as file:
-        try:
-            yaml_data = open_yaml_config(yaml_file)
+    try:
+        with open(yaml_file, "r") as f:
+            yaml_data = list(yaml.load_all(f, Loader=loader))
+
+        _print_with_colour(
+            "Sanity check of the YAML_CONFIG was successfully done...\n",
+            colour=Colour.GREEN,
+        )
+        return yaml_data
+    except yaml.parser.ParserError as e:
+        line = e.problem_mark.line
+        _print_with_colour(
+            f"Incorrect indentation in the YAML_CONFIG file at line {line}. "
+            "Please recheck the indentation of the file."
+        )
+    except yaml.scanner.ScannerError as e:
+        _print_with_colour(
+            f"Incorrect mapping in the YAML_CONFIG file at line {e.problem_mark.line + 1}."
+        )
+    except yaml.constructor.ConstructorError as e:
+        _print_with_colour(
+            f"Invalid tag in the YAML_CONFIG file at line {e.problem_mark.line + 1}."
+        )
+    except yaml.reader.ReaderError as e:
+        _print_with_colour(
+            f"Failed to parse YAML file at line {e.problem_mark.line + 1}: {e}"
+        )
+    except yaml.YAMLError as e:
+        if hasattr(e, "problem_mark"):
             _print_with_colour(
-                "Sanity check of the YAML_CONFIG was successfully done...\n",
-                colour=Colour.GREEN,
+                f"Error in the YAML_CONFIG file at line {e.problem_mark.line}. "
+                "Please recheck the file."
             )
-            return yaml_data
-        except yaml.parser.ParserError as e:
-            line = e.problem_mark.line
-            _print_with_colour(
-                f"Incorrect indentation in the YAML_CONFIG file at line {line}. "
-                "Please recheck the indentation of the file."
-            )
-        except yaml.scanner.ScannerError as e:
-            _print_with_colour(
-                f"Incorrect mapping in the YAML_CONFIG file at line {e.problem_mark.line + 1}."
-            )
-        except yaml.constructor.ConstructorError as e:
-            _print_with_colour(
-                f"Invalid tag in the YAML_CONFIG file at line {e.problem_mark.line + 1}."
-            )
-        except yaml.reader.ReaderError as e:
-            _print_with_colour(
-                f"Failed to parse YAML file at line {e.problem_mark.line + 1}: {e}"
-            )
-        except yaml.YAMLError as e:
-            if hasattr(e, "problem_mark"):
-                _print_with_colour(
-                    f"Error in the YAML_CONFIG file at line {e.problem_mark.line}. "
-                    "Please recheck the file."
-                )
 
 
 def check_all_stages_defined(

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -85,6 +85,27 @@ def check_all_stages_defined(
     return yaml_data
 
 
+def check_all_stages_non_empty(
+        yaml_file: str,
+        loader: type[YamlLoader]
+) -> Optional[PipelineConfig]:
+    """
+    Check if all three stages in the YAML (loading, pre-processing, main
+    processing) are non-empty.
+    """
+    with open(yaml_file, "r") as f:
+        yaml_data = list(yaml.load_all(f, Loader=loader))
+
+    for stage in yaml_data:
+        if stage is None:
+            _print_with_colour(
+                "Please make sure that all three stages in the pipeline YAML "
+                "file are not empty."
+            )
+            return
+    return yaml_data
+
+
 def check_one_method_per_module(yaml_file):
     """
     Check that we cannot have a yaml file with more than one method

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -8,7 +8,7 @@ import h5py
 import yaml
 
 from httomo.utils import Colour
-from httomo.yaml_utils import get_external_package_current_version, open_yaml_config
+from httomo.yaml_utils import get_external_package_current_version
 
 __all__ = [
     "check_one_method_per_module",

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -130,7 +130,10 @@ def check_loading_stage_one_method(
     return yaml_data
 
 
-def check_one_method_per_module(yaml_file):
+def check_one_method_per_module(
+        yaml_file: str,
+        loader: type[YamlLoader],
+):
     """
     Check that we cannot have a yaml file with more than one method
     being called from one module. For example, we cannot have:
@@ -149,18 +152,22 @@ def check_one_method_per_module(yaml_file):
         "\nDoing a sanity check first...",
         colour=Colour.GREEN,
     )
-    yaml_data = sanity_check(yaml_file)
+    sanity_check(yaml_file, loader)
+    check_all_stages_defined(yaml_file, loader)
+    check_all_stages_non_empty(yaml_file, loader)
+    yaml_data = check_loading_stage_one_method(yaml_file, loader)
 
-    lvalues = [value for d in yaml_data for value in d.values()]
-    for i, d in enumerate(lvalues):
-        assert isinstance(d, dict)
-        if len(d) != 1:
-            _print_with_colour(
-                f"More than one method is being called from the"
-                f" module '{next(iter(yaml_data[i]))}'. "
-                "Please recheck the yaml file."
-            )
-            return False
+    for stage in yaml_data:
+        lvalues = [value for d in stage for value in d.values()]
+        for i, d in enumerate(lvalues):
+            assert isinstance(d, dict)
+            if len(d) != 1:
+                _print_with_colour(
+                    f"More than one method is being called from the"
+                    f" module '{next(iter(stage[i]))}'. "
+                    "Please recheck the yaml file."
+                )
+                return False
 
     _print_with_colour(
         "'One method per module' check was also successfully done...\n",

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -106,6 +106,26 @@ def check_all_stages_non_empty(
     return yaml_data
 
 
+def check_loading_stage_one_method(
+        yaml_file: str,
+        loader: type[YamlLoader]
+) -> Optional[PipelineConfig]:
+    """
+    Check that the loading stage in the pipeline YAML has only one method in
+    it.
+    """
+    with open(yaml_file, "r") as f:
+        yaml_data = list(yaml.load_all(f, Loader=loader))
+
+    if len(yaml_data[0]) != 1:
+        _print_with_colour(
+            "Please make sure that the loading stage has only one method in "
+            "it, a loader method."
+        )
+        return
+    return yaml_data
+
+
 def check_one_method_per_module(yaml_file):
     """
     Check that we cannot have a yaml file with more than one method

--- a/httomo/yaml_loader.py
+++ b/httomo/yaml_loader.py
@@ -1,0 +1,47 @@
+from typing import Tuple, Union
+
+import yaml
+import numpy as np
+
+from httomo.utils import log_exception
+
+
+class YamlLoader(yaml.SafeLoader):
+    """
+    Load HTTomo pipeline YAML files.
+    """
+    def sweep_manual(self, node) -> Tuple[Union[int, float], ...]:
+        """
+        A parameter sweep defined by explicitly given values to sweep over.
+        This will simply be a tuple of the given values.
+        """
+        return tuple(self.construct_sequence(node))
+
+
+    def sweep_range(self, node) -> Tuple[Union[int, float], ...]:
+        """
+        A parameter sweep defined by a given range. This will be a tuple of
+        values which are defined based on the start, stop, step values that are
+        in the dict.
+        """
+        # Form a dict from the YAML marked by `!SweepRange`
+        range_dict = self.construct_mapping(node)
+        # Check that only 3 keys are in the given dict/mapping: `start`, `stop`,
+        # and `step`
+        keys = range_dict.keys()
+        is_valid_range = "start" in keys and "stop" in keys and "step" in keys
+        if not is_valid_range:
+            err_str = (
+                "Please provide `start`, `stop`, `step` values when "
+                "specifying a range to peform a parameter sweep over."
+            )
+            log_exception(err_str)
+            raise ValueError(err_str)
+
+        # Define the range based on the start, stop, step values
+        param_vals = np.arange(
+            range_dict["start"], range_dict["stop"], range_dict["step"]
+        )
+        param_vals = tuple(param_vals)
+        return param_vals
+

--- a/httomo/yaml_utils.py
+++ b/httomo/yaml_utils.py
@@ -1,56 +1,6 @@
 from pathlib import Path
-from typing import Any, Dict, List
 
-import numpy as np
 import yaml
-
-from httomo.utils import log_exception
-
-
-class Sweep(yaml.SafeLoader):
-    """Class for representing a parameter sweep when explicitly given the values
-    to sweep over. This will simply be a tuple of the given values.
-    """
-
-    def __init__(self, node):
-        return tuple(self.construct_sequence(node))
-
-
-class SweepRange(yaml.SafeLoader):
-    """Class for representing a parameter sweep over a given range. This will be
-    a tuple of values which are defined based on the start, stop, step values
-    that are in the dict.
-    """
-
-    def __init__(self, node):
-        # Form a dict from the YAML marked by `!SweepRange`
-        range_dict = self.construct_mapping(node)
-        # Check that only 3 keys are in the given dict/mapping: `start`, `stop`,
-        # and `step`
-        keys = range_dict.keys()
-        is_valid_range = "start" in keys and "stop" in keys and "step" in keys
-        if not is_valid_range:
-            err_str = (
-                "Please provide `start`, `stop`, `step` values when "
-                "specifying a range to peform a parameter sweep over."
-            )
-            log_exception(err_str)
-            raise ValueError(err_str)
-
-        # Define the range based on the start, stop, step values
-        param_vals = np.arange(
-            range_dict["start"], range_dict["stop"], range_dict["step"]
-        )
-        param_vals = tuple(param_vals)
-        return param_vals
-
-
-def _get_loader():
-    """Add Sweep and SweepRange constructors to PyYAML's SafeLoader."""
-    loader = yaml.SafeLoader
-    loader.add_constructor("!Sweep", Sweep.__init__)
-    loader.add_constructor("!SweepRange", SweepRange.__init__)
-    return loader
 
 
 def get_external_package_current_version(package: str) -> str:
@@ -66,22 +16,3 @@ def get_external_package_current_version(package: str) -> str:
 
     return str(versions[package]["current"][0])
 
-
-def open_yaml_config(filepath: Path) -> List[Dict[str, Dict[str, Dict[str, Any]]]]:
-    """Open and read a given YAML config file into a python data structure.
-
-    Parameters
-    ----------
-    filepath : Path
-        The file containing the YAML config.
-
-    Returns
-    -------
-    List[Dict[str, Dict[str, Dict[str, Any]]]]
-        A list of dicts, where each dict represents a task in the user config
-        YAML file.
-    """
-    with open(filepath, "r") as f:
-        conf = yaml.load(f, Loader=_get_loader())
-
-    return conf

--- a/samples/loader_configs/diad.yaml
+++ b/samples/loader_configs/diad.yaml
@@ -1,3 +1,4 @@
+--- # loading
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo

--- a/samples/loader_configs/standard_tomo.yaml
+++ b/samples/loader_configs/standard_tomo.yaml
@@ -1,3 +1,4 @@
+--- # loading
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo

--- a/samples/pipeline_template_examples/02_basic_cpu_pipeline_tomo_standard.yaml
+++ b/samples/pipeline_template_examples/02_basic_cpu_pipeline_tomo_standard.yaml
@@ -1,3 +1,4 @@
+--- # loading
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo
@@ -10,6 +11,19 @@
           stop: 60
         - 
       pad: 0
+--- # pre-normalisation / pre-processing
+- tomopy.recon.rotation:
+    find_center_vo:
+      data_in: tomo
+      data_out: cor
+      ind: mid
+      smin: -50
+      smax: 50
+      srad: 6
+      step: 0.25
+      ratio: 0.5
+      drop: 20
+--- # main processing
 - tomopy.prep.normalize:
     normalize:
       data_in: tomo
@@ -28,17 +42,6 @@
       wname: db5
       sigma: 2
       pad: true
-- tomopy.recon.rotation:
-    find_center_vo:
-      data_in: tomo
-      data_out: cor
-      ind: mid
-      smin: -50
-      smax: 50
-      srad: 6
-      step: 0.25
-      ratio: 0.5
-      drop: 20
 - tomopy.recon.algorithm:
     recon:
       data_in: tomo

--- a/samples/pipeline_template_examples/03_basic_gpu_pipeline_tomo_standard.yaml
+++ b/samples/pipeline_template_examples/03_basic_gpu_pipeline_tomo_standard.yaml
@@ -1,3 +1,4 @@
+--- # Loading stage
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo
@@ -9,32 +10,7 @@
         - 
         - 
       pad: 0
-- httomolibgpu.misc.corr:
-    remove_outlier3d:
-      data_in: tomo
-      data_out: tomo
-      kernel_size: 3
-      dif: 0.1
-- httomolibgpu.misc.corr:
-    remove_outlier3d:
-      data_in: flats
-      data_out: flats
-      kernel_size: 3
-      dif: 0.1
-- httomolibgpu.misc.corr:
-    remove_outlier3d:
-      data_in: darks
-      data_out: darks
-      kernel_size: 3
-      dif: 0.1
-- httomolibgpu.prep.normalize:
-    normalize:
-      data_in: tomo
-      data_out: tomo
-      cutoff: 10.0
-      minus_log: true
-      nonnegativity: false
-      remove_nans: false
+--- # Pre-normalisation / pre-processing stage
 - httomolibgpu.recon.rotation:
     find_center_vo:
       data_in: tomo
@@ -46,6 +22,14 @@
       step: 0.25
       ratio: 0.5
       drop: 20
+--- # Main processing stage
+- httomolibgpu.prep.normalize:
+    normalize:
+      data_in: tomo
+      data_out: tomo
+      cutoff: 10.0
+      minus_log: true
+      nonnegativity: false
 - httomolibgpu.prep.stripe:
     remove_stripe_based_sorting:
       data_in: tomo

--- a/samples/pipeline_template_examples/03_basic_gpu_pipeline_tomo_standard.yaml
+++ b/samples/pipeline_template_examples/03_basic_gpu_pipeline_tomo_standard.yaml
@@ -11,6 +11,10 @@
         - 
       pad: 0
 --- # Pre-normalisation / pre-processing stage
+- httomolibgpu.misc.corr:
+    remove_outlier3d:
+      kernel_size: 3
+      dif: 0.1
 - httomolibgpu.recon.rotation:
     find_center_vo:
       data_in: tomo

--- a/samples/pipeline_template_examples/parameter_sweeps/02_median_filter_kernel_sweep.yaml
+++ b/samples/pipeline_template_examples/parameter_sweeps/02_median_filter_kernel_sweep.yaml
@@ -1,3 +1,4 @@
+--- # loading
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo
@@ -5,6 +6,19 @@
       image_key_path: /entry1/tomo_entry/instrument/detector/image_key
       dimension: 1
       pad: 0
+--- # pre-normalisation / pre-processing
+- tomopy.recon.rotation:
+    find_center_vo:
+      data_in: tomo
+      data_out: cor
+      ind: mid
+      smin: -50
+      smax: 50
+      srad: 6
+      step: 0.25
+      ratio: 0.5
+      drop: 20
+--- # main processing
 - tomopy.misc.corr:
     median_filter:
       data_in: tomo
@@ -13,8 +27,3 @@
         - 3
         - 5
       axis: 0
-- tomopy.prep.normalize:
-    normalize:
-      data_in: tomo
-      data_out: tomo
-      cutoff: 10.0

--- a/samples/pipeline_template_examples/testing/empty_loader_stage.yaml
+++ b/samples/pipeline_template_examples/testing/empty_loader_stage.yaml
@@ -1,0 +1,54 @@
+--- # loading
+--- # pre-processing
+- tomopy.prep.normalize:
+    normalize:
+      data_in: tomo
+      data_out: tomo
+      cutoff: null
+- tomopy.prep.normalize:
+    minus_log:
+      data_in: tomo
+      data_out: tomo
+--- # main processing
+- tomopy.prep.stripe:
+    remove_stripe_fw:
+      data_in: tomo
+      data_out: tomo
+      level: null
+      wname: db5
+      sigma: 2
+      pad: true
+- tomopy.recon.rotation:
+    find_center_vo:
+      data_in: tomo
+      data_out: cor
+      ind: mid
+      smin: -50
+      smax: 50
+      srad: 6
+      step: 0.25
+      ratio: 0.5
+      drop: 20
+- tomopy.recon.algorithm:
+    recon:
+      data_in: tomo
+      data_out: tomo
+      center: cor
+      sinogram_order: false
+      algorithm: gridrec
+      init_recon: null
+      save_result: true
+      #additional parameters': AVAILABLE
+- httomolib.misc.images:
+    save_to_images:
+      data_in: tomo
+      subfolder_name: images
+      axis: 1
+      file_format: tif
+      bits: 8
+      perc_range_min: 0.0
+      perc_range_max: 100.0
+      jpeg_quality: 95
+      glob_stats: true
+
+

--- a/samples/pipeline_template_examples/testing/incorrect_method.yaml
+++ b/samples/pipeline_template_examples/testing/incorrect_method.yaml
@@ -1,3 +1,4 @@
+--- # loading
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo
@@ -9,12 +10,14 @@
           stop: 60
         - 
       pad: 0
+--- # pre-processing
 - tomopy.misc.corr:
     median_filters:
       data: tomo
       data_out: tomo
       size: tomo
       axis: 0
+--- # main processing
 - tomopy.prep.normalize:
     normalize:
       data_in: tomo

--- a/samples/pipeline_template_examples/testing/incorrect_path.yaml
+++ b/samples/pipeline_template_examples/testing/incorrect_path.yaml
@@ -1,5 +1,20 @@
+--- # loading
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo
       data_path: entry1/tomo_entry/data/data
       image_key_path: entry1/tomo_entry/instrument/detect/image_key
+--- # pre-processing
+- tomopy.prep.normalize:
+    minus_log:
+      data_in: tomo
+      data_out: tomo
+--- # main processing
+- tomopy.prep.stripe:
+    remove_stripe_fw:
+      data_in: tomo
+      data_out: tomo
+      level: null
+      wname: db5
+      sigma: 2
+      pad: true

--- a/samples/pipeline_template_examples/testing/invalid_loader_stage.yaml
+++ b/samples/pipeline_template_examples/testing/invalid_loader_stage.yaml
@@ -1,0 +1,60 @@
+--- # loading
+- httomo.data.hdf.loaders:
+    standard_tomo:
+      name: tomo
+      data_path: /entry1/tomo_entry/data/data
+      image_key_path: /entry1/tomo_entry/instrument/detector/image_key
+      dimension: 1
+      pad: 0
+- tomopy.prep.normalize:
+    normalize:
+      data_in: tomo
+      data_out: tomo
+      cutoff: null
+--- # pre-processing
+- tomopy.prep.normalize:
+    minus_log:
+      data_in: tomo
+      data_out: tomo
+--- # main processing
+- tomopy.prep.stripe:
+    remove_stripe_fw:
+      data_in: tomo
+      data_out: tomo
+      level: null
+      wname: db5
+      sigma: 2
+      pad: true
+- tomopy.recon.rotation:
+    find_center_vo:
+      data_in: tomo
+      data_out: cor
+      ind: mid
+      smin: -50
+      smax: 50
+      srad: 6
+      step: 0.25
+      ratio: 0.5
+      drop: 20
+- tomopy.recon.algorithm:
+    recon:
+      data_in: tomo
+      data_out: tomo
+      center: cor
+      sinogram_order: false
+      algorithm: gridrec
+      init_recon: null
+      save_result: true
+      #additional parameters': AVAILABLE
+- httomolib.misc.images:
+    save_to_images:
+      data_in: tomo
+      subfolder_name: images
+      axis: 1
+      file_format: tif
+      bits: 8
+      perc_range_min: 0.0
+      perc_range_max: 100.0
+      jpeg_quality: 95
+      glob_stats: true
+

--- a/samples/pipeline_template_examples/testing/missing_loader_stage.yaml
+++ b/samples/pipeline_template_examples/testing/missing_loader_stage.yaml
@@ -1,0 +1,52 @@
+--- # pre-processing
+- tomopy.prep.normalize:
+    normalize:
+      data_in: tomo
+      data_out: tomo
+      cutoff: null
+- tomopy.prep.normalize:
+    minus_log:
+      data_in: tomo
+      data_out: tomo
+--- # main processing
+- tomopy.prep.stripe:
+    remove_stripe_fw:
+      data_in: tomo
+      data_out: tomo
+      level: null
+      wname: db5
+      sigma: 2
+      pad: true
+- tomopy.recon.rotation:
+    find_center_vo:
+      data_in: tomo
+      data_out: cor
+      ind: mid
+      smin: -50
+      smax: 50
+      srad: 6
+      step: 0.25
+      ratio: 0.5
+      drop: 20
+- tomopy.recon.algorithm:
+    recon:
+      data_in: tomo
+      data_out: tomo
+      center: cor
+      sinogram_order: false
+      algorithm: gridrec
+      init_recon: null
+      save_result: true
+      #additional parameters': AVAILABLE
+- httomolib.misc.images:
+    save_to_images:
+      data_in: tomo
+      subfolder_name: images
+      axis: 1
+      file_format: tif
+      bits: 8
+      perc_range_min: 0.0
+      perc_range_max: 100.0
+      jpeg_quality: 95
+      glob_stats: true
+

--- a/samples/pipeline_template_examples/testing/more_than_one_method.yaml
+++ b/samples/pipeline_template_examples/testing/more_than_one_method.yaml
@@ -1,8 +1,10 @@
+--- # loading
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo
       data_path: entry1/tomo_entry/data/data
       image_key_path: entry1/tomo_entry/instrument/detector/image_key
+--- # pre-processing
 - tomopy.prep.normalize:
     normalize:
       data_in: tomo
@@ -11,3 +13,12 @@
     minus_log:
       data_in: tomo
       data_out: tomo
+--- # main processing
+- tomopy.prep.stripe:
+    remove_stripe_fw:
+      data_in: tomo
+      data_out: tomo
+      level: null
+      wname: db5
+      sigma: 2
+      pad: true

--- a/samples/pipeline_template_examples/testing/required_param.yaml
+++ b/samples/pipeline_template_examples/testing/required_param.yaml
@@ -1,3 +1,4 @@
+--- # loading
 - httomo.data.hdf.loaders:
     standard_tomo:
       name: tomo
@@ -5,6 +6,13 @@
       image_key_path: /entry1/tomo_entry/instrument/detector/image_key
       dimension: 1
       pad: 0
+--- # pre-processing
+- tomopy.prep.normalize:
+    normalize:
+      data_in: tomo
+      data_out: tomo
+      cutoff: null
+--- # main processing
 - tomopy.prep.stripe:
     stripes_mask3d:
       data_in: tomo

--- a/samples/pipeline_template_examples/testing/testing_pipeline.yaml
+++ b/samples/pipeline_template_examples/testing/testing_pipeline.yaml
@@ -1,3 +1,16 @@
+--- # pre-processing
+- tomopy.recon.rotation:
+    find_center_vo:
+      data_in: tomo
+      data_out: cor
+      ind: mid
+      smin: -50
+      smax: 50
+      srad: 6
+      step: 0.25
+      ratio: 0.5
+      drop: 20
+--- # main processing
 - tomopy.prep.normalize:
     normalize:
       data_in: tomo
@@ -15,17 +28,6 @@
       wname: db5
       sigma: 2
       pad: true
-- tomopy.recon.rotation:
-    find_center_vo:
-      data_in: tomo
-      data_out: cor
-      ind: mid
-      smin: -50
-      smax: 50
-      srad: 6
-      step: 0.25
-      ratio: 0.5
-      drop: 20
 - tomopy.recon.algorithm:
     recon:
       data_in: tomo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,9 @@ import numpy as np
 import pytest
 import yaml
 
+from httomo.yaml_loader import YamlLoader
+
+
 CUR_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -214,3 +217,10 @@ def merge_yamls():
             yaml.dump(data, file_descriptor)
 
     return _merge_yamls
+
+
+@pytest.fixture
+def yaml_loader() -> type[YamlLoader]:
+    YamlLoader.add_constructor("!Sweep", YamlLoader.sweep_manual)
+    YamlLoader.add_constructor("!SweepRange", YamlLoader.sweep_range)
+    return YamlLoader

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,9 +212,9 @@ def merge_yamls():
         data = []
         for y in yamls:
             with open(y, "r") as file_descriptor:
-                data.extend(yaml.load(file_descriptor, Loader=yaml.SafeLoader))
+                data.extend(yaml.load_all(file_descriptor, Loader=yaml.SafeLoader))
         with open("temp.yaml", "w") as file_descriptor:
-            yaml.dump(data, file_descriptor)
+            yaml.dump_all(data, file_descriptor)
 
     return _merge_yamls
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -26,8 +26,7 @@ def test_tomo_standard_testing_pipeline_loaded(
     assert "Running task 2 (pattern=projection): normalize..." in result.stderr
     assert "Running task 3 (pattern=projection): minus_log.." in result.stderr
     assert "Running task 4 (pattern=sinogram): remove_stripe_fw..." in result.stderr
-    assert "Running task 5 (pattern=sinogram): find_center_vo..." in result.stderr
-    assert "Running task 7 (pattern=all): save_to_images.." in result.stderr
+    assert "Running task 6 (pattern=all): save_to_images.." in result.stderr
     assert "Pipeline finished" in result.stderr
 
 
@@ -45,8 +44,7 @@ def test_diad_testing_pipeline_loaded(
     assert "Running task 2 (pattern=projection): normalize..." in result.stderr
     assert "Running task 3 (pattern=projection): minus_log.." in result.stderr
     assert "Running task 4 (pattern=sinogram): remove_stripe_fw..." in result.stderr
-    assert "Running task 5 (pattern=sinogram): find_center_vo..." in result.stderr
-    assert "Running task 7 (pattern=all): save_to_images.." in result.stderr
+    assert "Running task 6 (pattern=all): save_to_images.." in result.stderr
     assert "Pipeline finished" in result.stderr
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -252,7 +252,7 @@ def test_i12_testing_pipeline_output(
     assert "Reslicing not necessary, as there is only one process" in log_contents
     assert "Saving intermediate file: 4-tomopy-remove_stripe_fw-tomo.h5" in log_contents
     assert "The center of rotation for 180 degrees sinogram is 95.5" in log_contents
-    assert "Saving intermediate file: 6-tomopy-recon-tomo-gridrec.h5" in log_contents
+    assert "Saving intermediate file: 5-tomopy-recon-tomo-gridrec.h5" in log_contents
     assert "INFO | ~~~ Pipeline finished ~~~" in log_contents
 
 
@@ -297,7 +297,7 @@ def test_i12_testing_ignore_darks_flats_pipeline_output(
     assert "Reslicing not necessary, as there is only one process" in log_contents
     assert "Saving intermediate file: 4-tomopy-remove_stripe_fw-tomo.h5" in log_contents
     assert "The center of rotation for 180 degrees sinogram is 95.5" in log_contents
-    assert "Saving intermediate file: 6-tomopy-recon-tomo-gridrec.h5" in log_contents
+    assert "Saving intermediate file: 5-tomopy-recon-tomo-gridrec.h5" in log_contents
     assert "INFO | ~~~ Pipeline finished ~~~" in log_contents
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -150,7 +150,7 @@ def test_gpu_pipeline_output_with_save_all(
     subprocess.check_output(cmd)
 
     files = read_folder("output_dir/")
-    assert len(files) == 136
+    assert len(files) == 133
     
     # commenting this until we sort out statistics calculation
     tif_files = list(filter(lambda x: ".tif" in x, files))
@@ -162,28 +162,26 @@ def test_gpu_pipeline_output_with_save_all(
         assert arr.shape == (160, 160)
         total_sum += arr.sum()
 
-    assert total_sum == 193160265.0
+    assert total_sum == 185989420.0
 
     h5_files = list(filter(lambda x: ".h5" in x, files))
-    assert len(h5_files) == 6
+    assert len(h5_files) == 3
 
-    remove_outlier_tomo = list(
-        filter(lambda x: "remove_outlier3d-tomo.h5" in x, h5_files)
-    )[0]
     normalize_tomo = list(filter(lambda x: "normalize-tomo.h5" in x, h5_files))[0]
+    remove_stripe_tomo = list(filter(lambda x: "remove_stripe_based_sorting-tomo.h5" in x, h5_files))[0]
     fpb_recon_tomo = list(filter(lambda x: "FBP-tomo.h5" in x, h5_files))[0]
 
     with h5py.File(normalize_tomo, "r") as f:
         assert f["data"].shape == (180, 128, 160)
-        assert_allclose(np.sum(f["data"]), 1060863, atol=1e-5)
-        assert_allclose(np.mean(f["data"]), 0.287778, atol=1e-5)
-    with h5py.File(fpb_recon_tomo, "r") as f:
-        assert_allclose(np.sum(f["data"]), 2611.2117, atol=1e-5)
-        assert_allclose(np.mean(f["data"]), 0.000798, atol=1e-5)
-    with h5py.File(remove_outlier_tomo, "r") as f:
-        assert_allclose(np.sum(f["data"]), 2.981388e+09, atol=1e-5)
-        assert_allclose(np.mean(f["data"]), 808.75336, atol=1e-5)
+        assert_allclose(np.sum(f["data"]), 1062695.375, atol=1e-5)
+        assert_allclose(np.mean(f["data"]), 0.288275, atol=1e-5)
+    with h5py.File(remove_stripe_tomo, "r") as f:
         assert f["data"].shape == (180, 128, 160)
+        assert_allclose(np.sum(f["data"]), 1059103.125, atol=1e-5)
+        assert_allclose(np.mean(f["data"]), 0.287300, atol=1e-5)
+    with h5py.File(fpb_recon_tomo, "r") as f:
+        assert_allclose(np.sum(f["data"]), 2614.8481, atol=1e-5)
+        assert_allclose(np.mean(f["data"]), 0.000798, atol=1e-5)
 
 
 def test_i12_testing_pipeline_output(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -74,8 +74,8 @@ def test_tomo_standard_testing_pipeline_output(
             with h5py.File(file_to_open, "r") as f:
                 assert f["data"].shape == (160, 3, 160)
                 assert f["data"].dtype == np.float32
-                assert_allclose(np.mean(f["data"]), -7.02924e-06, atol=1e-6)
-                assert_allclose(np.sum(f["data"]), -0.539846, atol=1e-6)
+                assert_allclose(np.mean(f["data"]), -2.123908e-06, atol=1e-6)
+                assert_allclose(np.sum(f["data"]), -0.163116, atol=1e-6)
 
     #: some basic testing of the generated user.log file, because running the whole pipeline again
     #: will slow down the execution of the test suite.
@@ -337,8 +337,8 @@ def test_diad_testing_pipeline_output(
         if "tomopy-recon-tomo-gridrec.h5" in file_to_open:
             with h5py.File(file_to_open, "r") as f:
                 assert f["data"].shape == (26, 2, 26)
-                assert_allclose(np.mean(f["data"]), 0.005883, atol=1e-6)
-                assert_allclose(np.sum(f["data"]), 7.954298, atol=1e-6)
+                assert_allclose(np.mean(f["data"]), -0.000823, atol=1e-6)
+                assert_allclose(np.sum(f["data"]), -1.11251, atol=1e-6)
 
     log_files = list(filter(lambda x: ".log" in x, files))
     assert len(log_files) == 1

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -17,7 +17,6 @@ def _dummy():
 
 def make_test_method(
     gpu=False,
-    is_loader=False,
     pattern=Pattern.projection,
     module_name="testmodule",
     wrapper_function=None,
@@ -26,7 +25,6 @@ def make_test_method(
     return MethodFunc(
         cpu=not gpu,
         gpu=gpu,
-        is_loader=is_loader,
         module_name=module_name,
         pattern=pattern,
         method_func=_dummy,
@@ -36,7 +34,7 @@ def make_test_method(
 
 
 def test_determine_platform_sections_single() -> None:
-    methods = [make_test_method(is_loader=True, module_name="testloader")]
+    methods = [make_test_method()]
     sections = _determine_platform_sections(methods, save_all=False)
 
     assert len(sections) == 1
@@ -48,7 +46,7 @@ def test_determine_platform_sections_single() -> None:
 
 def test_determine_platform_sections_two_cpu() -> None:
     methods = [
-        make_test_method(is_loader=True, module_name="testloader"),
+        make_test_method(),
         make_test_method(),
     ]
     sections = _determine_platform_sections(methods, save_all=False)
@@ -62,9 +60,7 @@ def test_determine_platform_sections_two_cpu() -> None:
 
 def test_determine_platform_sections_pattern_change() -> None:
     methods = [
-        make_test_method(
-            is_loader=True, module_name="testloader", pattern=Pattern.projection
-        ),
+        make_test_method(pattern=Pattern.projection),
         make_test_method(pattern=Pattern.sinogram),
     ]
     sections = _determine_platform_sections(methods, save_all=False)
@@ -82,7 +78,7 @@ def test_determine_platform_sections_pattern_change() -> None:
 
 def test_determine_platform_sections_platform_change() -> None:
     methods = [
-        make_test_method(is_loader=True, module_name="testloader"),
+        make_test_method(gpu=False),
         make_test_method(gpu=True),
     ]
     sections = _determine_platform_sections(methods, save_all=False)
@@ -119,7 +115,7 @@ def test_determine_platform_sections_pattern_all_combine(
     pattern1: Pattern, pattern2: Pattern, expected: Pattern
 ) -> None:
     methods = [
-        make_test_method(pattern=pattern1, is_loader=True, module_name="testloader"),
+        make_test_method(pattern=pattern1),
         make_test_method(pattern=pattern2),
     ]
     sections = _determine_platform_sections(methods, save_all=False)

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -12,6 +12,7 @@ from httomo.yaml_checker import (
     check_loading_stage_one_method,
     check_methods_exist_in_templates,
     check_one_method_per_module,
+    check_valid_method_parameters,
     sanity_check,
     validate_yaml_config,
 )
@@ -97,19 +98,29 @@ def test_check_methods_exist_in_templates(
     assert not check_methods_exist_in_templates(conf)
 
 
+def test_check_valid_method_parameters(
+        sample_pipelines,
+        yaml_loader: type[YamlLoader]
+):
+    required_param_pipeline = (
+        sample_pipelines + "testing/required_param.yaml"
+    )
+    with open(required_param_pipeline, "r") as f:
+        conf = list(yaml.load_all(f, Loader=yaml_loader))
+    assert not check_valid_method_parameters(conf, yaml_loader)
+
+
 @pytest.mark.parametrize(
     "yaml_file, expected",
     [
         ("02_basic_cpu_pipeline_tomo_standard.yaml", True),
         ("03_basic_gpu_pipeline_tomo_standard.yaml", True),
         ("parameter_sweeps/02_median_filter_kernel_sweep.yaml", True),
-        ("testing/required_param.yaml", False),
     ],
     ids=[
         "cpu_pipeline",
         "gpu_pipeline",
         "sweep_pipeline",
-        "required_param",
     ],
 )
 def test_validate_yaml_config(sample_pipelines, yaml_file, standard_data, expected):

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -7,6 +7,7 @@ import yaml
 from httomo.yaml_checker import (
     check_all_stages_defined,
     check_all_stages_non_empty,
+    check_first_stage_has_loader,
     check_loading_stage_one_method,
     check_one_method_per_module,
     sanity_check,
@@ -54,6 +55,15 @@ def test_invalid_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
     assert not check_loading_stage_one_method(conf)
 
 
+def test_first_stage_has_loader(sample_pipelines, yaml_loader: type[YamlLoader]):
+    incorrect_first_stage_pipeline = (
+        sample_pipelines + "testing/incorrect_first_stage.yaml"
+    )
+    with open(incorrect_first_stage_pipeline, "r") as f:
+        conf = list(yaml.load_all(f, Loader=yaml_loader))
+    assert not check_first_stage_has_loader(conf)
+
+
 def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoader]):
     with open(more_than_one_method, "r") as f:
         conf = list(yaml.load_all(f, Loader=yaml_loader))
@@ -63,7 +73,6 @@ def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoade
 @pytest.mark.parametrize(
     "yaml_file, expected",
     [
-        ("testing/testing_pipeline.yaml", False),
         ("testing/incorrect_method.yaml", False),
         ("02_basic_cpu_pipeline_tomo_standard.yaml", True),
         ("03_basic_gpu_pipeline_tomo_standard.yaml", True),
@@ -72,7 +81,6 @@ def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoade
         ("testing/required_param.yaml", False),
     ],
     ids=[
-        "no_loader_pipeline",
         "incorrect_method",
         "cpu_pipeline",
         "gpu_pipeline",

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -123,6 +123,12 @@ def test_check_valid_method_parameters(
         "sweep_pipeline",
     ],
 )
-def test_validate_yaml_config(sample_pipelines, yaml_file, standard_data, expected):
+def test_validate_yaml_config(
+    sample_pipelines: str,
+    yaml_file: str,
+    standard_data: str,
+    expected: bool,
+    yaml_loader: type[YamlLoader]
+):
     yaml_file = sample_pipelines + yaml_file
-    assert validate_yaml_config(yaml_file, standard_data) == expected
+    assert validate_yaml_config(yaml_file, yaml_loader, standard_data) == expected

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -42,8 +42,8 @@ def test_invalid_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
     assert check_loading_stage_one_method(invalid_loader_stage_pipeline, yaml_loader) is None
 
 
-def test_one_method_per_module(more_than_one_method):
-    assert not check_one_method_per_module(more_than_one_method)
+def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoader]):
+    assert not check_one_method_per_module(more_than_one_method, yaml_loader)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -4,10 +4,12 @@ Some unit tests for the yaml checker
 import pytest
 
 from httomo.yaml_checker import (
+    check_all_stages_defined,
     check_one_method_per_module,
     sanity_check,
     validate_yaml_config,
 )
+from httomo.yaml_loader import YamlLoader
 
 
 def test_sanity_check(sample_pipelines):
@@ -15,6 +17,13 @@ def test_sanity_check(sample_pipelines):
         sample_pipelines + "testing/wrong_indentation_pipeline.yaml"
     )
     assert not sanity_check(wrong_indentation_pipeline)
+
+
+def test_missing_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
+    missing_loader_stage_pipeline = (
+        sample_pipelines + "testing/missing_loader_stage.yaml"
+    )
+    assert check_all_stages_defined(missing_loader_stage_pipeline, yaml_loader) is None
 
 
 def test_one_method_per_module(more_than_one_method):

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -5,6 +5,7 @@ import pytest
 
 from httomo.yaml_checker import (
     check_all_stages_defined,
+    check_all_stages_non_empty,
     check_one_method_per_module,
     sanity_check,
     validate_yaml_config,
@@ -24,6 +25,13 @@ def test_missing_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
         sample_pipelines + "testing/missing_loader_stage.yaml"
     )
     assert check_all_stages_defined(missing_loader_stage_pipeline, yaml_loader) is None
+
+
+def test_empty_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
+    empty_loader_stage_pipeline = (
+        sample_pipelines + "testing/empty_loader_stage.yaml"
+    )
+    assert check_all_stages_non_empty(empty_loader_stage_pipeline, yaml_loader) is None
 
 
 def test_one_method_per_module(more_than_one_method):

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -25,21 +25,21 @@ def test_missing_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
     missing_loader_stage_pipeline = (
         sample_pipelines + "testing/missing_loader_stage.yaml"
     )
-    assert check_all_stages_defined(missing_loader_stage_pipeline, yaml_loader) is None
+    assert not check_all_stages_defined(missing_loader_stage_pipeline, yaml_loader)
 
 
 def test_empty_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
     empty_loader_stage_pipeline = (
         sample_pipelines + "testing/empty_loader_stage.yaml"
     )
-    assert check_all_stages_non_empty(empty_loader_stage_pipeline, yaml_loader) is None
+    assert not check_all_stages_non_empty(empty_loader_stage_pipeline, yaml_loader)
 
 
 def test_invalid_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
     invalid_loader_stage_pipeline = (
         sample_pipelines + "testing/invalid_loader_stage.yaml"
     )
-    assert check_loading_stage_one_method(invalid_loader_stage_pipeline, yaml_loader) is None
+    assert not check_loading_stage_one_method(invalid_loader_stage_pipeline, yaml_loader)
 
 
 def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoader]):

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -8,6 +8,7 @@ from httomo.yaml_checker import (
     check_all_stages_defined,
     check_all_stages_non_empty,
     check_first_stage_has_loader,
+    check_hdf5_paths_against_loader,
     check_loading_stage_one_method,
     check_one_method_per_module,
     sanity_check,
@@ -70,6 +71,19 @@ def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoade
     assert not check_one_method_per_module(conf)
 
 
+def test_hdf5_paths_against_loader(
+        standard_data,
+        sample_pipelines,
+        yaml_loader: type[YamlLoader]
+):
+    incorrect_path_pipeline = (
+        sample_pipelines + "testing/incorrect_path.yaml"
+    )
+    with open(incorrect_path_pipeline, "r") as f:
+        conf = list(yaml.load_all(f, Loader=yaml_loader))
+    assert not check_hdf5_paths_against_loader(conf[0][0], standard_data)
+
+
 @pytest.mark.parametrize(
     "yaml_file, expected",
     [
@@ -77,7 +91,6 @@ def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoade
         ("02_basic_cpu_pipeline_tomo_standard.yaml", True),
         ("03_basic_gpu_pipeline_tomo_standard.yaml", True),
         ("parameter_sweeps/02_median_filter_kernel_sweep.yaml", True),
-        ("testing/incorrect_path.yaml", False),
         ("testing/required_param.yaml", False),
     ],
     ids=[
@@ -85,7 +98,6 @@ def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoade
         "cpu_pipeline",
         "gpu_pipeline",
         "sweep_pipeline",
-        "incorrect_path",
         "required_param",
     ],
 )

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -2,6 +2,7 @@
 Some unit tests for the yaml checker
 """
 import pytest
+import yaml
 
 from httomo.yaml_checker import (
     check_all_stages_defined,
@@ -18,32 +19,45 @@ def test_sanity_check(sample_pipelines, yaml_loader: type[YamlLoader]):
     wrong_indentation_pipeline = (
         sample_pipelines + "testing/wrong_indentation_pipeline.yaml"
     )
-    assert not sanity_check(wrong_indentation_pipeline, yaml_loader)
+    with open(wrong_indentation_pipeline, "r") as f:
+        conf_generator = yaml.load_all(f, Loader=yaml_loader)
+        # `assert` needs to be in `with` block for this case, because
+        # `conf_generator` is lazy-loaded from the file when converted to a
+        # list inside `sanity_check()`
+        assert not sanity_check(conf_generator)
 
 
 def test_missing_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
     missing_loader_stage_pipeline = (
         sample_pipelines + "testing/missing_loader_stage.yaml"
     )
-    assert not check_all_stages_defined(missing_loader_stage_pipeline, yaml_loader)
+    with open(missing_loader_stage_pipeline, "r") as f:
+        conf = list(yaml.load_all(f, Loader=yaml_loader))
+    assert not check_all_stages_defined(conf)
 
 
 def test_empty_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
     empty_loader_stage_pipeline = (
         sample_pipelines + "testing/empty_loader_stage.yaml"
     )
-    assert not check_all_stages_non_empty(empty_loader_stage_pipeline, yaml_loader)
+    with open(empty_loader_stage_pipeline, "r") as f:
+        conf = list(yaml.load_all(f, Loader=yaml_loader))
+    assert not check_all_stages_non_empty(conf)
 
 
 def test_invalid_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
     invalid_loader_stage_pipeline = (
         sample_pipelines + "testing/invalid_loader_stage.yaml"
     )
-    assert not check_loading_stage_one_method(invalid_loader_stage_pipeline, yaml_loader)
+    with open(invalid_loader_stage_pipeline, "r") as f:
+        conf = list(yaml.load_all(f, Loader=yaml_loader))
+    assert not check_loading_stage_one_method(conf)
 
 
 def test_one_method_per_module(more_than_one_method, yaml_loader: type[YamlLoader]):
-    assert not check_one_method_per_module(more_than_one_method, yaml_loader)
+    with open(more_than_one_method, "r") as f:
+        conf = list(yaml.load_all(f, Loader=yaml_loader))
+    assert not check_one_method_per_module(conf)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -10,6 +10,7 @@ from httomo.yaml_checker import (
     check_first_stage_has_loader,
     check_hdf5_paths_against_loader,
     check_loading_stage_one_method,
+    check_methods_exist_in_templates,
     check_one_method_per_module,
     sanity_check,
     validate_yaml_config,
@@ -84,17 +85,27 @@ def test_hdf5_paths_against_loader(
     assert not check_hdf5_paths_against_loader(conf[0][0], standard_data)
 
 
+def test_check_methods_exist_in_templates(
+        sample_pipelines,
+        yaml_loader: type[YamlLoader]
+):
+    incorrect_method_pipeline = (
+        sample_pipelines + "testing/incorrect_method.yaml"
+    )
+    with open(incorrect_method_pipeline, "r") as f:
+        conf = list(yaml.load_all(f, Loader=yaml_loader))
+    assert not check_methods_exist_in_templates(conf)
+
+
 @pytest.mark.parametrize(
     "yaml_file, expected",
     [
-        ("testing/incorrect_method.yaml", False),
         ("02_basic_cpu_pipeline_tomo_standard.yaml", True),
         ("03_basic_gpu_pipeline_tomo_standard.yaml", True),
         ("parameter_sweeps/02_median_filter_kernel_sweep.yaml", True),
         ("testing/required_param.yaml", False),
     ],
     ids=[
-        "incorrect_method",
         "cpu_pipeline",
         "gpu_pipeline",
         "sweep_pipeline",

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -6,6 +6,7 @@ import pytest
 from httomo.yaml_checker import (
     check_all_stages_defined,
     check_all_stages_non_empty,
+    check_loading_stage_one_method,
     check_one_method_per_module,
     sanity_check,
     validate_yaml_config,
@@ -32,6 +33,13 @@ def test_empty_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
         sample_pipelines + "testing/empty_loader_stage.yaml"
     )
     assert check_all_stages_non_empty(empty_loader_stage_pipeline, yaml_loader) is None
+
+
+def test_invalid_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):
+    invalid_loader_stage_pipeline = (
+        sample_pipelines + "testing/invalid_loader_stage.yaml"
+    )
+    assert check_loading_stage_one_method(invalid_loader_stage_pipeline, yaml_loader) is None
 
 
 def test_one_method_per_module(more_than_one_method):

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -14,11 +14,11 @@ from httomo.yaml_checker import (
 from httomo.yaml_loader import YamlLoader
 
 
-def test_sanity_check(sample_pipelines):
+def test_sanity_check(sample_pipelines, yaml_loader: type[YamlLoader]):
     wrong_indentation_pipeline = (
         sample_pipelines + "testing/wrong_indentation_pipeline.yaml"
     )
-    assert not sanity_check(wrong_indentation_pipeline)
+    assert not sanity_check(wrong_indentation_pipeline, yaml_loader)
 
 
 def test_missing_loader_stage(sample_pipelines, yaml_loader: type[YamlLoader]):


### PR DESCRIPTION
Main changes:
- add loader and pre-processing stages to pipeline YAML files via multiple "documents" within the YAML file
- enable dezinging (optional) and centering (mandatory) as part of the pre-processing stage
- try out defining a class for reading pipeline YAML files, as a test candidate for some refactoring
- refactor `test_yaml_checker.py` such that each individual check can be tested in isolation