### PR TITLE
Fix incorrect data shape used for single sino gather

### DIFF
--- a/httomo/data/dataset_store.py
+++ b/httomo/data/dataset_store.py
@@ -248,6 +248,7 @@ class DataSetStoreWriter(ReadableDataSetSink):
                 darks=dataset.darks,
                 global_index=self.chunk_index,
                 chunk_shape=self.chunk_shape,
+                shape=self.global_shape,
             )
 
     @classmethod
@@ -330,6 +331,7 @@ class DataSetStoreReader(DataSetSource):
                 darks=source._data.darks,
                 global_index=source.chunk_index,
                 chunk_shape=source.chunk_shape,
+                shape=self.global_shape,
             )
 
         if slicing_dim is None or slicing_dim == source.slicing_dim:
@@ -429,6 +431,7 @@ class DataSetStoreReader(DataSetSource):
                     darks=data.darks,
                     global_index=self._chunk_idx,
                     chunk_shape=self._chunk_shape,
+                    shape=self.global_shape,
                 )
 
     def read_block(self, start: int, length: int) -> DataSetBlock:

--- a/httomo/method_wrappers/rotation.py
+++ b/httomo/method_wrappers/rotation.py
@@ -113,7 +113,7 @@ class RotationWrapper(GenericMethodWrapper):
         if not dataset.is_last_in_chunk:  # exit if we didn't process all blocks yet
             return dataset
 
-        sino_slice = self._gather_sino_slice(dataset.global_shape)
+        sino_slice = self._gather_sino_slice(dataset.base.shape)
 
         # now calculate the center of rotation on rank 0 and broadcast
         res: Optional[Union[tuple, float, np.float32]] = None

--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -417,6 +417,7 @@ class FullFileDataSet(DataSet):
         darks: np.ndarray,
         global_index: Tuple[int, int, int],
         chunk_shape: Tuple[int, int, int],
+        shape: Tuple[int, int, int],
     ):
         super().__init__(
             data,
@@ -427,10 +428,11 @@ class FullFileDataSet(DataSet):
             global_index,
         )
         self._chunk_shape = chunk_shape
+        self._shape = shape
 
     @property
     def shape(self) -> Tuple[int, int, int]:
-        return self._global_shape
+        return self._shape
 
     @property
     def chunk_shape(self) -> Tuple[int, int, int]:

--- a/httomo/runner/loader.py
+++ b/httomo/runner/loader.py
@@ -135,6 +135,7 @@ class StandardTomoLoader(DataSetSource):
             darks=darks_arr,
             global_index=self._chunk_index,
             chunk_shape=self._chunk_shape,
+            shape=self._global_shape,
         )
 
         weakref.finalize(self, self.finalize)

--- a/tests/runner/test_dataset.py
+++ b/tests/runner/test_dataset.py
@@ -382,6 +382,7 @@ def test_fullfiledataset_has_correct_shapes():
         darks=2 * np.ones((5, 10, 10)),
         global_index=(0, 0, 0),
         chunk_shape=CHUNK_SHAPE,
+        shape=GLOBAL_DATA_SHAPE,
     )
 
     assert dummy_dataset.chunk_shape == CHUNK_SHAPE
@@ -407,6 +408,7 @@ def test_datasetblock_from_fullfiledataset_has_correct_shapes():
         darks=2 * np.ones((5, 10, 10)),
         global_index=(0, 0, 0),
         chunk_shape=CHUNK_SHAPE,
+        shape=GLOBAL_DATA_SHAPE,
     )
 
     block = dummy_dataset.make_block(SLICING_DIM, BLOCK_START, BLOCK_LENGTH)
@@ -454,6 +456,7 @@ def test_fullfile_dataset_can_set_full_data():
         darks=2 * np.ones((5, 10, 10)),
         global_index=(0, 0, 0),
         chunk_shape=CHUNK_SHAPE,
+        shape=GLOBAL_DATA_SHAPE,
     )
 
     dataset.data = np.ones(CHUNK_SHAPE, dtype=np.float32)
@@ -477,6 +480,7 @@ def test_fullfile_dataset_cannot_change_shape():
         darks=2 * np.ones((5, 10, 10)),
         global_index=(0, 0, 0),
         chunk_shape=CHUNK_SHAPE,
+        shape=GLOBAL_DATA_SHAPE,
     )
 
     with pytest.raises(ValueError) as e:
@@ -500,6 +504,7 @@ def test_fullfile_dataset_cannot_change_dtype():
         darks=2 * np.ones((5, 10, 10)),
         global_index=(0, 0, 0),
         chunk_shape=CHUNK_SHAPE,
+        shape=GLOBAL_DATA_SHAPE,
     )
 
     with pytest.raises(ValueError) as e:
@@ -523,6 +528,7 @@ def test_fullfile_dataset_transfers_to_cpu():
         darks=2 * np.ones((5, 10, 10)),
         global_index=(0, 0, 0),
         chunk_shape=CHUNK_SHAPE,
+        shape=GLOBAL_DATA_SHAPE,
     )
     
     dataset.data = xp.ones(CHUNK_SHAPE, dtype=np.float32)


### PR DESCRIPTION
The issue was that the gathering of the single sinogram slice was using the shape of the global data _including_ darks/flats, rather than the shape of the data with the darks/flats _excluded_.

It was possible to fix by fiddling with the `shape` and `global_shape` properties of the data objects, but it should be considered a workaround rather than a proper fix, fiddling with these various properties feels fragile.