### PR TITLE
Bugfix: Memory estimation including darks and flats

### DIFF
--- a/httomo/data/dataset_store.py
+++ b/httomo/data/dataset_store.py
@@ -352,8 +352,16 @@ class DataSetStoreReader(DataSetSource):
         return self._data.darks
     
     @property
+    def has_gpu_darks(self) -> bool:
+        return self._data.has_gpu_darks
+    
+    @property
     def flats(self) -> np.ndarray:
         return self._data.flats
+    
+    @property
+    def has_gpu_flats(self) -> bool:
+        return self._data.has_gpu_flats
     
     @property
     def is_file_based(self) -> bool:

--- a/httomo/methods_database/packages/external/httomolibgpu/1.2/httomolibgpu.yaml
+++ b/httomo/methods_database/packages/external/httomolibgpu/1.2/httomolibgpu.yaml
@@ -36,9 +36,9 @@ prep:
       implementation: gpu_cupy
       save_result_default: False
       memory_gpu:
-        - datasets: [tomo, flats, darks]
-        - multipliers: [2, 1.075, 1.075]
-        - methods: [direct, direct, direct]
+        - datasets: [tomo]
+        - multipliers: [None]
+        - methods: [module]
   phase:
     paganin_filter_tomopy:
       pattern: projection

--- a/httomo/methods_database/packages/external/httomolibgpu/1.2/httomolibgpu.yaml
+++ b/httomo/methods_database/packages/external/httomolibgpu/1.2/httomolibgpu.yaml
@@ -16,8 +16,8 @@ misc:
       save_result_default: False
       memory_gpu:
         - datasets: [tomo]
-        - multipliers: [2.1]
-        - methods: [direct]
+        - multipliers: [None]
+        - methods: [module]
   morph:
     sino_360_to_180:
       pattern: sinogram

--- a/httomo/methods_database/packages/external/httomolibgpu/supporting_funcs/misc/corr.py
+++ b/httomo/methods_database/packages/external/httomolibgpu/supporting_funcs/misc/corr.py
@@ -1,0 +1,39 @@
+from typing import Tuple
+import numpy as np
+
+
+__all__ = [
+    "_calc_memory_bytes_remove_outlier3d",
+]
+
+def _calc_memory_bytes_remove_outlier3d(
+        non_slice_dims_shape: Tuple[int, int],
+        dtype: np.dtype,
+        **kwargs,
+) -> Tuple[int, int]:
+    # this function is implicitly replaced with the dezinging wrapper, 
+    # which applies it 3 times - to data, darks, and flats
+    
+    # it does not change the data type of the inputs
+    in_slice_mem = np.prod(non_slice_dims_shape) * dtype.itemsize
+    out_slice_mem = in_slice_mem
+    
+    # fixed cost for input/output of darks/flats - it makes a copy of these
+    darks_flats_mem = 0
+    darks_shape = kwargs["darks_shape"]
+    darks_dtype = kwargs["darks_dtype"]
+    darks_mem = int(np.prod(darks_shape) * darks_dtype.itemsize)
+    flats_mem = int(np.prod(darks_shape) * darks_dtype.itemsize)
+    
+    # for memory calculation, we have to take into account that the input data is dropped after
+    # an execution, freeing the memory for the next call afterwards. 
+    # so if darks/flats are smaller than data, they will re-use that memory that has just been freed
+    #
+    # Because we don't know the size of the data at this point, we can't be accurate here. For a 
+    # conservative estimate, we assume that flats/darks memory comes in addition to the data memory.
+    # But we only need to consider the greater of the two (the other will re-use)
+    darks_flats_mem = max(darks_mem, flats_mem)
+
+    tot_memory_bytes = int(in_slice_mem + out_slice_mem)
+
+    return (tot_memory_bytes, darks_flats_mem)

--- a/httomo/methods_database/packages/external/httomolibgpu/supporting_funcs/prep/normalize.py
+++ b/httomo/methods_database/packages/external/httomolibgpu/supporting_funcs/prep/normalize.py
@@ -1,0 +1,23 @@
+from typing import Tuple
+import numpy as np
+
+
+__all__ = [
+    "_calc_memory_bytes_normalize",
+]
+
+def _calc_memory_bytes_normalize(
+        non_slice_dims_shape: Tuple[int, int],
+        dtype: np.dtype,
+        **kwargs,
+) -> Tuple[int, int]:
+     # this function changes the data type
+    in_slice_mem = np.prod(non_slice_dims_shape) * dtype.itemsize
+    out_slice_mem = np.prod(non_slice_dims_shape) * np.float32().itemsize
+    
+    # fixed cost for keeping mean of flats and darks
+    mean_mem = int(np.prod(non_slice_dims_shape) * np.float32().itemsize * 2)
+
+    tot_memory_bytes = int(in_slice_mem + out_slice_mem)
+
+    return (tot_memory_bytes, mean_mem)

--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -62,6 +62,14 @@ class DataSet:
             self._darks_dirty: bool = False
 
     @property
+    def has_gpu_darks(self) -> bool:
+        return gpu_enabled and self._darks_gpu is not None
+    
+    @property
+    def has_gpu_flats(self) -> bool:
+        return gpu_enabled and self._flats_gpu is not None
+
+    @property
     def global_shape(self) -> Tuple[int, int, int]:
         """Overall shape of the data, regardless of chunking and blocking"""
         return self._global_shape
@@ -401,6 +409,14 @@ class DataSetBlock(DataSet):
         self, field: str, is_gpu: Optional[bool] = None
     ) -> DataSet.generic_array:
         return self._base.get_value(field, self.is_gpu if is_gpu is None else is_gpu)
+    
+    @property
+    def has_gpu_darks(self) -> bool:
+        return self._base.has_gpu_darks
+    
+    @property
+    def has_gpu_flats(self) -> bool:
+        return self._base.has_gpu_flats
 
     def make_block(self, dim: int, start: int = 0, length: Optional[int] = None):
         raise ValueError("Cannot slice a dataset that is already a slice")

--- a/httomo/runner/dataset_store_interfaces.py
+++ b/httomo/runner/dataset_store_interfaces.py
@@ -81,8 +81,18 @@ class DataSetSource(Protocol):
         ...  # pragma: no cover
         
     @property
+    def has_gpu_darks(self) -> bool:
+        """Check if darks array has already been cached on the GPU"""
+        ...  # pragma: no cover
+        
+    @property
     def flats(self) -> np.ndarray:
         """Flats array"""
+        ...  # pragma: no cover
+        
+    @property
+    def has_gpu_flats(self) -> bool:
+        """Check if flats array has already been cached on the GPU"""
         ...  # pragma: no cover
 
     def read_block(self, start: int, length: int) -> DataSetBlock:

--- a/httomo/runner/loader.py
+++ b/httomo/runner/loader.py
@@ -152,6 +152,14 @@ class StandardTomoLoader(DataSetSource):
     @property
     def darks(self) -> np.ndarray:
         return self._data.darks
+    
+    @property
+    def has_gpu_darks(self) -> bool:
+        return self._data.has_gpu_darks
+    
+    @property
+    def has_gpu_flats(self) -> bool:
+        return self._data.has_gpu_flats
 
     @property
     def slicing_dim(self) -> Literal[0, 1, 2]:

--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -49,19 +49,21 @@ class TaskRunner:
         self.start_time = MPI.Wtime()
 
         sections = self._sectionize()
-        
+
         self._prepare()
         for i, section in enumerate(sections):
             self._execute_section(section, i)
             gpumem_cleanup()
-            
+
         self.end_time = MPI.Wtime()
-        self._log_pipeline(f"Pipeline finished. Took {self.end_time-self.start_time:.3f}s")
-            
+        self._log_pipeline(
+            f"Pipeline finished. Took {self.end_time-self.start_time:.3f}s"
+        )
+
     def _sectionize(self) -> List[Section]:
         sections = sectionize(self.pipeline)
         self._log_pipeline(f"Pipeline has been separated into {len(sections)} sections")
-        num_stores = len(sections) - 1 
+        num_stores = len(sections) - 1
         if num_stores > 1:
             log_once(
                 f"WARNING: Reslicing will be performed {num_stores} times. The number of reslices increases the total run time.",
@@ -157,12 +159,18 @@ class TaskRunner:
     def _execute_method(
         self, method: MethodWrapper, block: DataSetBlock
     ) -> DataSetBlock:
-        start_time = self._log_task_start(method.task_id, method.pattern, method.method_name)
+        start_time = self._log_task_start(
+            method.task_id, method.pattern, method.method_name
+        )
         block = method.execute(block)
         if block.is_last_in_chunk:
             self.append_side_outputs(method.get_side_output())
         self._log_task_end(
-            method.task_id, start_time, method.pattern, method.method_name, method.package_name
+            method.task_id,
+            start_time,
+            method.pattern,
+            method.method_name,
+            method.package_name,
         )
         return block
 
@@ -243,6 +251,8 @@ class TaskRunner:
         log_once(memory_str, comm=self.comm, colour=Colour.BVIOLET, level=1)
         max_slices_methods = [max_slices] * len(section)
 
+        available_memory -= self._darks_flats_gpu_memory(section)
+
         # loop over all methods in section
         has_gpu = False
         for idx, m in enumerate(section):
@@ -263,6 +273,21 @@ class TaskRunner:
             non_slice_dims_shape = output_dims
 
         if not has_gpu:
-            section.max_slices = min(min(max_slices_methods), httomo.globals.MAX_CPU_SLICES)
+            section.max_slices = min(
+                min(max_slices_methods), httomo.globals.MAX_CPU_SLICES
+            )
         else:
             section.max_slices = min(max_slices_methods)
+
+    def _darks_flats_gpu_memory(self, section: Section):
+        mem = 0
+        assert self.source is not None, "Source not set"
+        if not self.source.has_gpu_darks and any(
+            m.cupyrun and "darks" in m.parameters for m in section
+        ):
+            mem += self.source.darks.nbytes
+        if not self.source.has_gpu_flats and any(
+            m.cupyrun and "flats" in m.parameters for m in section
+        ):
+            mem += self.source.flats.nbytes
+        return mem

--- a/tests/method_wrappers/test_generic.py
+++ b/tests/method_wrappers/test_generic.py
@@ -582,7 +582,11 @@ def test_generic_calculate_max_slices_module(
     if gpu_enabled:
         assert max_slices == (1_000_000_000 - 5678) // 1234
         assert available_memory == 1_000_000_000
-        memcalc_mock.assert_called_once_with(tuple(shape), dummy_dataset.data.dtype)
+        memcalc_mock.assert_called_once_with(tuple(shape), dummy_dataset.data.dtype,
+                                             darks_shape=dummy_dataset.darks.shape, 
+                                             flats_shape=dummy_dataset.flats.shape, 
+                                             darks_dtype=dummy_dataset.darks.dtype, 
+                                             flats_dtype=dummy_dataset.flats.dtype)
     else:
         assert max_slices > dummy_dataset.data.shape[0]
         assert available_memory == 1_000_000_000

--- a/tests/runner/test_dataset.py
+++ b/tests/runner/test_dataset.py
@@ -367,6 +367,8 @@ def test_block_caches_in_base_on_gpu_access(dataset: DataSet):
     
     assert dataset.has_gpu_flats is False
     assert dataset.has_gpu_darks is True
+    assert block.has_gpu_flats is False
+    assert block.has_gpu_darks is True
 
 
 def test_setting_data_in_block_updates_global_shape(dataset):

--- a/tests/test_backends/test_httomolibgpu.py
+++ b/tests/test_backends/test_httomolibgpu.py
@@ -51,12 +51,15 @@ class MaxMemoryHook(cp.cuda.MemoryHook):
     def malloc_preprocess(self, **kwargs):
         pass
 
+
 @pytest.mark.parametrize("dtype", ["uint16", "float32"])
+@pytest.mark.parametrize("slices", [50, 121])
 @pytest.mark.cupy
-def test_normalize_memoryhook(data, flats, darks, ensure_clean_memory, dtype):
+def test_normalize_memoryhook(flats, darks, ensure_clean_memory, dtype, slices):
     hook = MaxMemoryHook()
+    data = cp.random.random_sample((slices, flats.shape[1], flats.shape[2]), dtype=np.float32)
     if dtype == "uint16":
-        darks = darks.astype(np.uint16)
+        darks = (darks * 1233).astype(np.uint16)
         flats = flats.astype(np.uint16)
         data = data.astype(np.uint16)
     with hook:
@@ -70,16 +73,10 @@ def test_normalize_memoryhook(data, flats, darks, ensure_clean_memory, dtype):
     )  # the amount of memory in bytes needed for the method according to memoryhook
 
     # now we estimate how much of the total memory required for this data
-    library_info = get_method_info(
-        "httomolibgpu.prep.normalize", "normalize", "memory_gpu"
-    )
-
-    # now we estimate how much of the total memory required for this data
     (estimated_memory_bytes, subtract_bytes) = _calc_memory_bytes_normalize(
         data.shape[1:], dtype=data.dtype
     )
 
-    slices = data.shape[0]
     estimated_memory_mb = round(slices*estimated_memory_bytes / (1024**2), 2)
     max_mem -= subtract_bytes
     max_mem_mb = round(max_mem / (1024**2), 2)
@@ -93,39 +90,6 @@ def test_normalize_memoryhook(data, flats, darks, ensure_clean_memory, dtype):
     assert percents_relative_maxmem <= 20
 
 
-@pytest.mark.cupy
-@pytest.mark.parametrize("slices", [128, 256, 512])
-def test_normalize_memoryhook_parametrise(slices, ensure_clean_memory):
-    data_size_dim = 512
-    data = cp.random.random_sample((slices, data_size_dim, data_size_dim), dtype=np.float32)
-    darks = cp.random.random_sample((20, data_size_dim, data_size_dim), dtype=np.float32)
-    flats = cp.random.random_sample((20, data_size_dim, data_size_dim), dtype=np.float32)
-    hook = MaxMemoryHook()
-    with hook:
-        data_normalize = normalize(cp.copy(data), flats, darks, minus_log=True).get()
-
-    # make sure estimator function is within range (80% min, 100% max)
-    max_mem = hook.max_mem # the amount of memory in bytes needed for the method according to memoryhook
-    max_mem_mb = round(max_mem / (1024**2), 2) # now in mbs
-   
-    # now we estimate how much of the total memory required for this data
-    library_info = get_method_info("httomolibgpu.prep.normalize", "normalize", "memory_gpu")
-    for i, dst in enumerate(library_info[0]['datasets']):
-        if dst == "flats":
-            flats_bytes = library_info[1]['multipliers'][i] * np.prod(cp.shape(flats)) * float32().nbytes
-        elif dst == "darks":
-            darks_bytes = library_info[1]['multipliers'][i] * np.prod(cp.shape(darks)) * float32().nbytes
-        else:            
-            data_bytes = library_info[1]['multipliers'][i] * np.prod(cp.shape(data)) * float32().nbytes
-    estimated_memory_bytes = flats_bytes + darks_bytes + data_bytes
-    estimated_memory_mb = round(estimated_memory_bytes / (1024**2), 2)
-    # now compare both memory estimations 
-    difference_mb = abs(estimated_memory_mb - max_mem_mb)
-    percents_relative_maxmem = round((difference_mb/max_mem_mb)*100)
-    # the estimated_memory_mb should be LARGER or EQUAL to max_mem_mb
-    # the resulting percent value should not deviate from max_mem on more than 20%    
-    assert estimated_memory_mb >= max_mem_mb 
-    assert percents_relative_maxmem <= 20
 
 @pytest.mark.cupy
 @pytest.mark.parametrize("slices", [64, 128])

--- a/tests/test_method_query.py
+++ b/tests/test_method_query.py
@@ -78,10 +78,9 @@ def test_database_query_object():
     assert query.swap_dims_on_output() is False
     assert query.save_result_default() is False
     mempars = query.get_memory_gpu_params()
-    assert len(mempars) == 3
-    assert set(p.dataset for p in mempars) == set(["tomo", "flats", "darks"])
-    assert all(p.method == "direct" for p in mempars)
-    assert all(p.multiplier >= 1.0 for p in mempars)
+    assert set(p.dataset for p in mempars) == set(["tomo"])
+    assert all(p.method == "module" for p in mempars)
+    assert all(p.multiplier == 'None' for p in mempars)
 
 
 def test_database_query_object_recon_swap_output():


### PR DESCRIPTION
This is a bugfix PR to fix the issue that memory / slices estimation did not take into account the size of the darks and flats, and the fact that they are transferred lazily to the GPU on demand. The fix works as follows.

### `DataSet` properties

- `DataSet` and classes inheriting from it have new properties `has_gpu_flats` and `has_gpu_darks`, which return a boolean depending if the lazy GPU transfer has already happend and the data is present in GPU memory already

### `calc_max_slices` in the `TaskRunner`

- The memory estimation in `TaskRunner` first checks if any methods in the section need `darks` and `flats` as inputs, and if they are GPU methods
- If yes, it checks if the `darks` / `flats` have already been transferred to GPU (using `has_gpu_darks` and `has_gpu_flats`)
    - If yes, the figure obtained for `available_memory_gpu` is left as it was
    - If not, we know that they are transferred somewhere in this section, so the available memory is reduced by the amount taken for the darks and flats

### Memory estimator functions

- the `calc_max_slices` module type estimator functions now get extra keyword parameters for the darks and flats shape and dtype
- They can use this information if they need to, in case the `darks` and `flats` affect the estimate
- this was needed for the `remove_outlier3d` estimator described below

### Memory estimator for `normalize`

- Previously, multipliers with the direct method had been used for `darks` and `flats` in normalize
- This is however wrong - if these fields are already on the GPU, no new memory will be needed for them (normalise does not modify `darks` and `flats` in any way)
- The estimator has been modified to use `module` (since normalize can change the data type of `data`), and darks/flats are simply ignored there (no allocations happen in `normalize` depending on `darks` and `flats`)

### Memory estimator for `remove_outlier3d`

- This method is in fact replaced by the `dezinging` method wrapper in `httomo`
- This wrapper applies the method 3 times - to `data`, `darks`, and `flats`
- It does not modify the data type of the input though - that's left the same
- Therefore the estimator has been written as `module`, taking all this into account + a test has been added for the memory hook
- Note that because of the cupy memory pool (with memory re-used between calls in some cases), the hook test only works accurately if the data is large (which is what we care about in practice)