### PR TITLE
Use alternative default val for image saver async param in template generator

### DIFF
--- a/templates/httomolib/1.2/httomolib.misc.images/save_to_images.yaml
+++ b/templates/httomolib/1.2/httomolib.misc.images/save_to_images.yaml
@@ -9,3 +9,4 @@
     perc_range_max: 100.0
     jpeg_quality: 95
     glob_stats: ${{statistics.side_outputs.glob_stats}}
+    asynchronous: true

--- a/templates/yaml_templates_generator.py
+++ b/templates/yaml_templates_generator.py
@@ -110,6 +110,8 @@ def _set_param_value(name: str, value: inspect.Parameter, params_dict: Dict[str,
         params_dict["#additional parameters"] = "AVAILABLE"
     elif name == "axis":
         params_dict[name] = 'auto'
+    elif name == "asynchronous":
+        params_dict[name] = True
     elif name == "center":
         # Temporary value
         params_dict[name] = "${{centering.side_outputs.centre_of_rotation}}"


### PR DESCRIPTION
Part of the work towards completing #246 

Goes together with the `asynchronous` parameter added to the image saver in https://github.com/DiamondLightSource/httomolib/pull/9