### PR TITLE
Remove import from non-existent `yaml_utils` module

### DIFF
--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -10,8 +10,6 @@ import yaml
 
 from pathlib import Path
 
-from httomo.yaml_utils import get_packages_current_version
-
 from httomo.ui_layer import (
     get_regex_pattern,
     get_ref_split,


### PR DESCRIPTION
Fixes tests failing to run due to the import of a now removed module (was removed in #282)

Acceptance criteria checklist:

- [x] All tests pass