### PR TITLE
Fix incorrect methods database YAML file globbing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ include = ["httomo*"]
 [tool.setuptools.package-data]
 httomo = ["methods_database/packages/*.yaml",
           "methods_database/packages/external/*.yaml",
-          "methods_database/packages/external/httomolibgpu/*/*.yaml",
-          "methods_database/packages/external/httomolib/*/*.yaml",
-          "methods_database/packages/external/tomopy/*/*.yaml",
+          "methods_database/packages/external/httomolibgpu/*.yaml",
+          "methods_database/packages/external/httomolib/*.yaml",
+          "methods_database/packages/external/tomopy/*.yaml",
           "../yaml_templates/httomolib/*/httomolib.misc.corr/*.yaml",
           "../yaml_templates/httomolib/*/httomolib.misc.images/*.yaml",
           "../yaml_templates/httomolib/*/httomolib.misc.segm/*.yaml",


### PR DESCRIPTION
Fixes #333

Acceptance criteria checklist:
- [x] Doing `pip install .` copies the methods database YAML files for httomolib, httomolibgpu, and tomopy to the installation directory