### PR TITLE
Add CLI flags to configure syslog handler

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - conda-forge::click>=8.1.3
   - conda-forge::cupy<=12.3.0
   - conda-forge::cudatoolkit
+  - conda-forge::graypy
   - conda-forge::h5py=*=*mpi_openmpi*
   - conda-forge::hdf5plugin
   - conda-forge::loguru

--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -106,6 +106,18 @@ def check(yaml_config: Path, in_data_file: Path = None):
     default=sys.stdout,
     help="File to store the monitoring output. Defaults to '-', which denotes stdout"
 )
+@click.option(
+    "--syslog-host",
+    type=click.STRING,
+    default="localhost",
+    help="Host of the syslog server",
+)
+@click.option(
+    "--syslog-port",
+    type=click.INT,
+    default=514,
+    help="Port on the host the syslog server is running on",
+)
 def run(
     in_data_file: Path,
     yaml_config: Path,
@@ -118,6 +130,8 @@ def run(
     max_memory: str,
     monitor: List[str],
     monitor_output: TextIO,
+    syslog_host: str,
+    syslog_port: int,
 ):
     """Run a pipeline defined in YAML on input data."""
 
@@ -127,6 +141,9 @@ def run(
     if max_cpu_slices < 1:
         raise ValueError("max-cpu-slices must be greater or equal to 1")
     httomo.globals.MAX_CPU_SLICES = max_cpu_slices
+
+    httomo.globals.SYSLOG_SERVER = syslog_host
+    httomo.globals.SYSLOG_PORT = syslog_port
 
     # Define httomo.globals.run_out_dir in all MPI processes
     if create_folder is None:

--- a/httomo/globals.py
+++ b/httomo/globals.py
@@ -5,3 +5,5 @@ run_out_dir: os.PathLike = Path('.')
 gpu_id: int = -1
 # maximum slices to use in CPU-only section
 MAX_CPU_SLICES: int = 64
+SYSLOG_SERVER = "localhost"
+SYSLOG_PORT = 514

--- a/httomo/logger.py
+++ b/httomo/logger.py
@@ -1,7 +1,10 @@
+import graypy
 import sys
 from pathlib import Path
 
 from loguru import logger
+
+from httomo import globals
 
 
 def setup_logger(out_path: Path):
@@ -14,3 +17,6 @@ def setup_logger(out_path: Path):
     logger.add(sink=concise_logfile_path, level="INFO", colorize=False, format="{message}")
     # Verbose logs written to file
     logger.add(sink=verbose_logfile_path, level="DEBUG", colorize=False, enqueue=True)
+    # Verbose logs sent to syslog server in GELF format
+    syslog_handler = graypy.GELFTCPHandler(globals.SYSLOG_SERVER, globals.SYSLOG_PORT)
+    logger.add(sink=syslog_handler, level="DEBUG", colorize=False)


### PR DESCRIPTION
Fixes #296

Acceptance criteria checklist:
- [x] Run httomo locally with `--syslog-host=graylog-log-target.diamond.ac.uk --syslog-port=12227` and confirm verbose logs appear in the httomo graylog stream https://graylog.diamond.ac.uk/streams/65a15e36ff8fbc2159e13f7f/search (see the following for example of a run's logs https://graylog.diamond.ac.uk/search?rangetype=absolute&from=2024-05-21T08%3A55%3A41.639Z&to=2024-05-21T09%3A05%3A41.639Z&q=file%3A%22%5C%2Fdls%5C%2Fscience%5C%2Fusers%5C%2Ftwi18192%5C%2Fhttomo%5C%2Fhttomo%5C%2Futils.py%22+AND+source%3A%22cs05r%5C-sc%5C-gpu05%5C-25.diamond.ac.uk%22+AND+gl2_source_input%3A%2265a15c25ff8fbc2159e13b56%22&highlightMessage=99c546c1-1750-11ef-a69c-fae0dce5bd43&streams=65a15e36ff8fbc2159e13f7f)