### PR TITLE
Change cupy installation prints to debug logs

### DIFF
--- a/httomo/utils.py
+++ b/httomo/utils.py
@@ -13,19 +13,21 @@ from httomo.data import mpiutil
 gpu_enabled = False
 try:
     import cupy as xp
+    if mpiutil.rank == 0:
+        logger.debug("CuPy is installed")
 
     try:
         xp.cuda.Device(0).compute_capability
         gpu_enabled = True  # CuPy is installed and GPU is available
     except xp.cuda.runtime.CUDARuntimeError:
         import numpy as xp
-
-        print("CuPy is installed but GPU device inaccessible")
+        if mpiutil.rank == 0:
+            logger.debug("CuPy is installed but GPU device inaccessible")
 
 except ImportError:
     import numpy as xp
-
-    print("CuPy is not installed")
+    if mpiutil.rank == 0:
+        logger.debug("CuPy is not installed")
 
 
 def log_once(output: Any, level: int = logging.INFO) -> None:


### PR DESCRIPTION
Fixes #301

Acceptance criteria checklist:
- [x] In conjunction with the tentative fix to launcher issue https://gitlab.diamond.ac.uk/scisoft/tomography/httomo_dls/-/issues/23, the print statement of "CuPy is not installed" when running the launcher on `wilson` doesn't appear

Before change:
```
(/dls/science/users/twi18192/conda-envs/httomo) [twi18192@cs04r-sc-vserv-300 httomo (log-cupy-install-info)]$ python -m httomo_dls.launcher
CuPy is not installed
Usage: python -m httomo_dls.launcher [OPTIONS] IN_DATA_FILE YAML_CONFIG
                                     OUT_DIR
Try 'python -m httomo_dls.launcher --help' for help.

Error: Missing argument 'IN_DATA_FILE'.
```

After change:
```
(/dls/science/users/twi18192/conda-envs/httomo) [twi18192@cs04r-sc-vserv-300 httomo (log-cupy-install-info)]$ python -m httomo_dls.launcher
Usage: python -m httomo_dls.launcher [OPTIONS] IN_DATA_FILE YAML_CONFIG
                                     OUT_DIR
Try 'python -m httomo_dls.launcher --help' for help.

Error: Missing argument 'IN_DATA_FILE'.
```