### PR TITLE
Build conda packages for openmpi "external" and "regular" build variants

### DIFF
--- a/conda/recipe/conda_build_config.yaml
+++ b/conda/recipe/conda_build_config.yaml
@@ -3,3 +3,6 @@ python:
   - 3.10
 numpy:
   - 1.24
+openmpi_build:
+  - regular
+  - external

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   preserve_egg_dir: False
-  number: 0
+  string: py{{ py }}_openmpi_{{ openmpi_build }}
 
 test:
   files:
@@ -60,6 +60,11 @@ requirements:
     - pyyaml
     - numpy<=1.25
     - nvtx
+    {% if openmpi_build == 'regular' %}
+    - openmpi
+    {% else %}
+    - openmpi * *external*
+    {% endif %}
     - python
     - plumbum
     - tomobar


### PR DESCRIPTION
Fixes #352
Depends on #347 being merged first

## Package naming

The generated package names look something like the following (fixing it for python 3.10, and httomo version v2.0.0rc1 for the example):
```
httomo-2.0.0rc1_openmpi_regular
httomo-2.0.0rc1_openmpi_external
```

"Regular" and "external" refer to the build strings of the `openmpi` package that the different httomo package builds are based on.

I chose these names as a starting point just to get the work done, but the names themselves can easily be changed, so opinions on better naming are certainly welcome :)

## Installation in practise with these changes

Assume that  the packages are uploaded to the httomo conda channel.

Installation of the package using the "external" openmpi build variant (for installation at DLS) would be done via:
```
mamba install -c https://conda.anaconda.org/httomo/ httomo=2.0.0rc1=*external*
```

Installation of the package using the  "regular" openmpi build variant (for installation outside of DLS) would be done via:
```
mamba install -c https://conda.anaconda.org/httomo/ httomo=2.0.0rc1=*regular*
```

## Acceptance criteria checklist
- [x] The built packages install the correct `openmpi` package build variant
- [x] There is a consensus on the names of the different build variants of the httomo package