### PR TITLE
Adds missing dependencies to pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,11 @@ dynamic = ["version"]
 dependencies = [
     "click",
     "numpy",
-    "httomolib"
+    "httomolib",
+    "loguru",
+    "typing-extensions",
+    "tqdm",
+    "graypy"
 ]
 
 [project.scripts]


### PR DESCRIPTION
These dependencies have been missing in the pyproject dependency specs. Code is not runnable without.