### PR TITLE
Adds padding capability to blocks

### DIFF
--- a/httomo/block_interfaces.py
+++ b/httomo/block_interfaces.py
@@ -130,6 +130,16 @@ class BlockIndexing(Protocol):
     def slicing_dim(self) -> Literal[0, 1, 2]:
         """Return the slicing dimenions of the block"""
         ...  # pragma: no cover
+        
+    @property
+    def is_padded(self) -> bool:
+        """Determine if this is a padded block"""
+        ...  # pragma: no cover
+        
+    @property
+    def padding(self) -> Tuple[int, int]:
+        """Get the left and right padding values for this block (0, 0 is returned if no padding is used)"""
+        ...  # pragma: no cover
 
 
 class Block(BlockData, BlockIndexing, BlockTransfer, Protocol):

--- a/httomo/block_interfaces.py
+++ b/httomo/block_interfaces.py
@@ -138,7 +138,11 @@ class BlockIndexing(Protocol):
         
     @property
     def padding(self) -> Tuple[int, int]:
-        """Get the before and after padding values for this block (0, 0 is returned if no padding is used)"""
+        """Get the 'before' and 'after' padding values for this block. 
+        This is to be understood as the the number of padding slices in the 'slicing_dim' direction
+        that come before and after the core area of the block. 
+        If no padding is used, it returns (0, 0).
+        """
         ...  # pragma: no cover
 
 

--- a/httomo/block_interfaces.py
+++ b/httomo/block_interfaces.py
@@ -138,7 +138,7 @@ class BlockIndexing(Protocol):
         
     @property
     def padding(self) -> Tuple[int, int]:
-        """Get the left and right padding values for this block (0, 0 is returned if no padding is used)"""
+        """Get the before and after padding values for this block (0, 0 is returned if no padding is used)"""
         ...  # pragma: no cover
 
 

--- a/httomo/block_interfaces.py
+++ b/httomo/block_interfaces.py
@@ -90,6 +90,11 @@ class BlockData(Protocol):
     def shape(self) -> Tuple[int, int, int]:
         """Shape of the data in this block"""
         ...  # pragma: no cover
+        
+    @property
+    def shape_unpadded(self) -> Tuple[int, int, int]:
+        """Shape of the core date in this block, with padding removed"""
+        ...  # pragma: no cover
 
 
 class BlockIndexing(Protocol):
@@ -102,15 +107,30 @@ class BlockIndexing(Protocol):
     def chunk_index(self) -> Tuple[int, int, int]:
         """The index of this block within the chunk handled by the current process"""
         ...  # pragma: no cover
+        
+    @property
+    def chunk_index_unpadded(self) -> Tuple[int, int, int]:
+        """The index of the core area of this block within the chunk (padding removed)"""
+        ...  # pragma: no cover
 
     @property
     def chunk_shape(self) -> Tuple[int, int, int]:
         """Shape of the full chunk handled by the current process"""
         ...  # pragma: no cover
+        
+    @property
+    def chunk_shape_unpadded(self) -> Tuple[int, int, int]:
+        """Shape of the full chunk core area handled by the current process (with padding removed)"""
+        ...  # pragma: no cover
 
     @property
     def global_index(self) -> Tuple[int, int, int]:
         """The index of this block within the global data across all processes"""
+        ...  # pragma: no cover
+        
+    @property
+    def global_index_unpadded(self) -> Tuple[int, int, int]:
+        """The index of the core area of this block within the global data across all processes (with padding removed)"""
         ...  # pragma: no cover
 
     @property

--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -85,6 +85,8 @@ class DataSetBlock(BaseBlock, BlockIndexing):
         self._check_inconsistencies()
 
     def _check_inconsistencies(self):
+        if self.padding[0] < 0 or self.padding[1] < 0:
+            raise ValueError("padding values cannot be negative")
         if self.chunk_index[self.slicing_dim] + self._padding[0] < 0:
             raise ValueError("block start index must be >= 0")
         if (

--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -110,12 +110,16 @@ class DataSetBlock(BaseBlock, BlockIndexing):
             for i in range(3)
             if i != self.slicing_dim
         ):
-            raise ValueError("chunk shape is larger than the global shape")
+            raise ValueError(
+                "chunk shape is larger than the global shape in non-slicing dimensions"
+            )
         if (
             self.chunk_shape[self.slicing_dim] - self.padding[0] - self.padding[1]
             > self.global_shape[self.slicing_dim]
         ):
-            raise ValueError("chunk shape is larger than the global shape")
+            raise ValueError(
+                "chunk shape is larger than the global shape in slicing dimension"
+            )
         if any(self.shape[i] > self.chunk_shape[i] for i in range(3)):
             raise ValueError("block shape is larger than the chunk shape")
         if any(

--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -24,7 +24,7 @@ class DataSetBlock(BaseBlock, BlockIndexing):
         chunk_shape: Optional[Tuple[int, int, int]] = None,
         padding: Tuple[int, int] = (0, 0),
     ):
-        """Constructs a data block for processing in the pipeline in high troughput runs.
+        """Constructs a data block for processing in the pipeline in high throughput runs.
 
         Parameters
         ----------

--- a/httomo/sweep_runner/param_sweep_block.py
+++ b/httomo/sweep_runner/param_sweep_block.py
@@ -3,11 +3,12 @@ from typing import Literal, Tuple
 import numpy as np
 
 from httomo.base_block import BaseBlock
+from httomo.block_interfaces import BlockIndexing
 from httomo.runner.auxiliary_data import AuxiliaryData
 from httomo.utils import make_3d_shape_from_array
 
 
-class ParamSweepBlock(BaseBlock):
+class ParamSweepBlock(BaseBlock, BlockIndexing):
     """
     Data storage type for block processing in parameter sweep runs
     """
@@ -52,3 +53,20 @@ class ParamSweepBlock(BaseBlock):
     @property
     def padding(self) -> Tuple[int, int]:
         return (0, 0)
+
+    @property
+    def shape_unpadded(self) -> Tuple[int, int, int]:
+        return self.shape
+
+    @property
+    def chunk_index_unpadded(self) -> Tuple[int, int, int]:
+        return self.chunk_index
+
+    @property
+    def chunk_shape_unpadded(self) -> Tuple[int, int, int]:
+        return self.chunk_shape
+
+    @property
+    def global_index_unpadded(self) -> Tuple[int, int, int]:
+        return self.global_index
+

--- a/httomo/sweep_runner/param_sweep_block.py
+++ b/httomo/sweep_runner/param_sweep_block.py
@@ -44,3 +44,11 @@ class ParamSweepBlock(BaseBlock):
     @property
     def slicing_dim(self) -> Literal[0, 1, 2]:
         return self._slicing_dim
+
+    @property
+    def is_padded(self) -> bool:
+        return False
+
+    @property
+    def padding(self) -> Tuple[int, int]:
+        return (0, 0)

--- a/tests/runner/test_dataset_block.py
+++ b/tests/runner/test_dataset_block.py
@@ -187,11 +187,12 @@ def test_partial_block_for_chunked_data_with_padding_center(
     padded_block_shape_t = unpadded_block_shape_t
     padded_block_shape_t[slicing_dim] += padding[0] + padding[1]
     padded_block_shape = make_3d_shape_from_shape(padded_block_shape_t)
-    padded_block_start_index = 3
-    unpadded_block_start_index = padded_block_start_index + padding[0]
 
-    padded_chunk_start_index = 10
-    unpadded_chunk_start_index = padded_chunk_start_index + padding[0]
+    unpadded_block_start_index = 5
+    padded_block_start_index = unpadded_block_start_index - padding[0]
+
+    unpadded_chunk_start_index = 12
+    padded_chunk_start_index = unpadded_chunk_start_index - padding[0]
 
     data = np.ones(padded_block_shape, dtype=np.float32)
     angles = np.linspace(0, math.pi, global_shape[0], dtype=np.float32)
@@ -254,8 +255,8 @@ def test_partial_block_for_chunked_data_with_padding_chunk_boundaries(
     )
     padded_block_start_index = unpadded_block_start_index - padding[0]
 
-    padded_chunk_start_index = 10
-    unpadded_chunk_start_index = padded_chunk_start_index + padding[0]
+    unpadded_chunk_start_index = 12
+    padded_chunk_start_index = unpadded_chunk_start_index - padding[0]
 
     data = np.ones(padded_block_shape, dtype=np.float32)
     angles = np.linspace(0, math.pi, global_shape[0], dtype=np.float32)

--- a/tests/runner/test_dataset_block.py
+++ b/tests/runner/test_dataset_block.py
@@ -160,13 +160,13 @@ def test_partial_block_for_chunked_data_with_padding_center(
 
 
 @pytest.mark.parametrize("slicing_dim", [0, 1, 2])
-@pytest.mark.parametrize("boundary", ["left", "right"])
+@pytest.mark.parametrize("boundary", ["before", "after"])
 def test_partial_block_for_chunked_data_with_padding_chunk_boundaries(
-    slicing_dim: Literal[0, 1, 2], boundary: Literal["left", "right"]
+    slicing_dim: Literal[0, 1, 2], boundary: Literal["before", "after"]
 ):
     block_shape = [10, 10, 10]
     block_shape[slicing_dim] = 6
-    start_index = -2 if boundary == "left" else 6
+    start_index = -2 if boundary == "before" else 6
     data = np.ones(block_shape, dtype=np.float32)
     global_index = [0, 0, 0]
     global_index[slicing_dim] = 10 + start_index
@@ -190,18 +190,18 @@ def test_partial_block_for_chunked_data_with_padding_chunk_boundaries(
 
     assert block.is_padded is True
     assert block.padding == (2, 2)
-    assert block.is_last_in_chunk is (boundary == "right")
+    assert block.is_last_in_chunk is (boundary == "after")
 
 
 @pytest.mark.parametrize("slicing_dim", [0, 1, 2])
-@pytest.mark.parametrize("boundary", ["left", "right"])
+@pytest.mark.parametrize("boundary", ["before", "after"])
 def test_partial_block_with_padding_global_boundaries(
-    slicing_dim: Literal[0, 1, 2], boundary: Literal["left", "right"]
+    slicing_dim: Literal[0, 1, 2], boundary: Literal["before", "after"]
 ):
     block_shape = [10, 10, 10]
     block_shape[slicing_dim] = 6
     padding = (2, 2)
-    start_index = -padding[0] if boundary == "left" else 6
+    start_index = -padding[0] if boundary == "before" else 6
     data = np.ones(block_shape, dtype=np.float32)
     chunk_shape_t = [10, 10, 10]
     chunk_shape_t[slicing_dim] += padding[0] + padding[1]  # for padding
@@ -209,10 +209,10 @@ def test_partial_block_with_padding_global_boundaries(
     global_index = [0, 0, 0]
     global_index[slicing_dim] = (
         -padding[0]
-        if boundary == "left"
+        if boundary == "before"
         else 30 - block_shape[slicing_dim] + padding[1]
     )
-    chunk_start = -padding[0] if boundary == "left" else 20 - padding[0]
+    chunk_start = -padding[0] if boundary == "before" else 20 - padding[0]
     global_shape_t = [10, 10, 10]
     global_shape_t[slicing_dim] = 30
     global_shape = make_3d_shape_from_shape(global_shape_t)
@@ -231,7 +231,7 @@ def test_partial_block_with_padding_global_boundaries(
     assert block.is_padded is True
     assert block.padding == padding
     assert block.global_index == tuple(global_index)
-    assert block.is_last_in_chunk is (boundary == "right")
+    assert block.is_last_in_chunk is (boundary == "after")
 
 
 # block_shape <= chunk_shape


### PR DESCRIPTION
A small PR which simply adds interfaces and capabilities to the `DataSetBlock` for padding. It works as follows:

- a `padding` parameter is added to the constructor, which is a tuple of 2 `int` values. It means the number of padded slices to the left and to the right. 
- `block_shape` is adapted to include the padding, i.e. a `(2, 3)` padded block with a core shape of `(10, 3, 4)` and slicing dim `0` means it will  have `block_shape=(15, 3, 4)`.  This includes the 5 padding slices.
- `chunk_shape` is adapted in the same way - the shape is the previous chunk shape + the padding
- `chunk_index` and `global_index` are the indices within the chunk data or global data, respectively, where the block starts, so this includes the padding as well. This means there can be negative indices as well - i.e. a block or chunk with `padding=(2, 2)` can have a starting index of `-2` and can run "over the boundary" by 2. This makes sure that the `data` field of the block plugs into the right position of the global data in all cases.
- However, the `global_shape` has not been adapted for padding - I believe that should always be the true global data, regardless of padding. The padding feature is something that's required for chunking and blocking the global data for consistency, but has nothing to do with the full global shape. 

In addition, `*_unpadded` properties have been added to the blocks for convenience, so that the indexes and shapes of the core area of this block can be easily retrieved. This is to help with writing to the dataset store, etc.

The tests have been adapted to handle padding, consistency checks modified, and all existing tests are still working (as padding defaults to `(0, 0)`. 