### PR TITLE
DataSetStore with padding support

### DIFF
--- a/httomo/block_interfaces.py
+++ b/httomo/block_interfaces.py
@@ -44,7 +44,7 @@ class BlockData(Protocol):
 
     @data.setter
     def data(self, new_data: generic_array): ...  # pragma: no cover
-
+    
     @property
     def aux_data(self) -> AuxiliaryData: ...  # pragma: no cover
 
@@ -163,6 +163,11 @@ class BlockIndexing(Protocol):
         that come before and after the core area of the block. 
         If no padding is used, it returns (0, 0).
         """
+        ...  # pragma: no cover
+
+    @property
+    def data_unpadded(self) -> generic_array: 
+        """Return the data, but with the padding slices removed"""
         ...  # pragma: no cover
 
 

--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Tuple
+from typing import List, Literal, Optional, Tuple
 
 import numpy as np
 
@@ -234,3 +234,13 @@ class DataSetBlock(BaseBlock, BlockIndexing):
         idx = list(index)
         idx[self.slicing_dim] += self.padding[0]
         return make_3d_shape_from_shape(idx)
+
+    @property
+    def data_unpadded(self) -> generic_array:
+        if not self.padding:
+            return self.data
+        d = self.data
+        slices = [slice(None), slice(None), slice(None)]
+        slices[self.slicing_dim] = slice(self.padding[0], d.shape[self.slicing_dim] - self.padding[1])
+        return d[slices[0], slices[1], slices[2]]
+

--- a/httomo/sweep_runner/param_sweep_block.py
+++ b/httomo/sweep_runner/param_sweep_block.py
@@ -2,7 +2,7 @@ from typing import Literal, Tuple
 
 import numpy as np
 
-from httomo.base_block import BaseBlock
+from httomo.base_block import BaseBlock, generic_array
 from httomo.block_interfaces import BlockIndexing
 from httomo.runner.auxiliary_data import AuxiliaryData
 from httomo.utils import make_3d_shape_from_array
@@ -14,10 +14,7 @@ class ParamSweepBlock(BaseBlock, BlockIndexing):
     """
 
     def __init__(
-        self,
-        data: np.ndarray,
-        aux_data: AuxiliaryData,
-        slicing_dim: Literal[0, 1, 2]
+        self, data: np.ndarray, aux_data: AuxiliaryData, slicing_dim: Literal[0, 1, 2]
     ) -> None:
         super().__init__(data, aux_data)
         self._slicing_dim = slicing_dim
@@ -41,7 +38,7 @@ class ParamSweepBlock(BaseBlock, BlockIndexing):
     @property
     def is_last_in_chunk(self) -> bool:
         return True
-    
+
     @property
     def slicing_dim(self) -> Literal[0, 1, 2]:
         return self._slicing_dim
@@ -70,3 +67,6 @@ class ParamSweepBlock(BaseBlock, BlockIndexing):
     def global_index_unpadded(self) -> Tuple[int, int, int]:
         return self.global_index
 
+    @property
+    def data_unpadded(self) -> generic_array:
+        return self.data

--- a/tests/data/test_dataset_store.py
+++ b/tests/data/test_dataset_store.py
@@ -13,26 +13,30 @@ from httomo.utils import make_3d_shape_from_shape
 
 
 @pytest.mark.parametrize("slicing_dim", [0, 1, 2])
-def test_writer_can_set_sizes_and_shapes_dim(tmp_path: PathLike, slicing_dim: Literal[0, 1, 2]):
-    global_shape=(30, 15, 20)
-    chunk_shape_t=list(global_shape)
+def test_writer_can_set_sizes_and_shapes_dim(
+    tmp_path: PathLike, slicing_dim: Literal[0, 1, 2]
+):
+    global_shape = (30, 15, 20)
+    chunk_shape_t = list(global_shape)
     chunk_shape_t[slicing_dim] = 5
     chunk_shape = make_3d_shape_from_shape(chunk_shape_t)
-    global_index_t=[0, 0, 0]
+    global_index_t = [0, 0, 0]
     global_index_t[slicing_dim] = 5
     global_index = make_3d_shape_from_shape(global_index_t)
     writer = DataSetStoreWriter(
-        slicing_dim=slicing_dim,        
+        slicing_dim=slicing_dim,
         comm=MPI.COMM_SELF,
         temppath=tmp_path,
     )
-    block = DataSetBlock(data=np.ones(chunk_shape, dtype=np.float32),
-                         aux_data=AuxiliaryData(angles=np.ones(global_shape[0], dtype=np.float32)),
-                         chunk_shape=chunk_shape,
-                         slicing_dim=slicing_dim,
-                         global_shape=global_shape,
-                         block_start=0,
-                         chunk_start=global_index[slicing_dim])
+    block = DataSetBlock(
+        data=np.ones(chunk_shape, dtype=np.float32),
+        aux_data=AuxiliaryData(angles=np.ones(global_shape[0], dtype=np.float32)),
+        chunk_shape=chunk_shape,
+        slicing_dim=slicing_dim,
+        global_shape=global_shape,
+        block_start=0,
+        chunk_start=global_index[slicing_dim],
+    )
     writer.write_block(block)
 
     assert writer.global_shape == global_shape
@@ -43,7 +47,7 @@ def test_writer_can_set_sizes_and_shapes_dim(tmp_path: PathLike, slicing_dim: Li
 
 def test_reader_throws_if_no_data(tmp_path: PathLike):
     writer = DataSetStoreWriter(
-        slicing_dim=0,        
+        slicing_dim=0,
         comm=MPI.COMM_SELF,
         temppath=tmp_path,
     )
@@ -62,7 +66,7 @@ def test_can_write_and_read_blocks(
         comm=MPI.COMM_WORLD,
         temppath=tmp_path,
     )
-    
+
     GLOBAL_SHAPE = (10, 10, 10)
     global_data = np.arange(np.prod(GLOBAL_SHAPE), dtype=np.float32).reshape(
         GLOBAL_SHAPE
@@ -70,22 +74,22 @@ def test_can_write_and_read_blocks(
     chunk_shape = (4, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2])
     chunk_start = 3
     block1 = DataSetBlock(
-        data=global_data[chunk_start:chunk_start+2, :, :],
+        data=global_data[chunk_start : chunk_start + 2, :, :],
         aux_data=AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0], dtype=np.float32)),
         global_shape=GLOBAL_SHAPE,
         chunk_shape=chunk_shape,
         block_start=0,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
     block2 = DataSetBlock(
-        data=global_data[chunk_start+2:chunk_start+2+2, :, :],
+        data=global_data[chunk_start + 2 : chunk_start + 2 + 2, :, :],
         aux_data=AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0], dtype=np.float32)),
         global_shape=GLOBAL_SHAPE,
         chunk_shape=chunk_shape,
         block_start=2,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
 
     if file_based:
@@ -112,7 +116,10 @@ def test_can_write_and_read_blocks(
 
 @pytest.mark.parametrize("file_based", [False, True])
 def test_write_after_read_throws(
-    mocker: MockerFixture, dummy_block: DataSetBlock, tmp_path: PathLike, file_based: bool
+    mocker: MockerFixture,
+    dummy_block: DataSetBlock,
+    tmp_path: PathLike,
+    file_based: bool,
 ):
     writer = DataSetStoreWriter(
         slicing_dim=0,
@@ -186,22 +193,22 @@ def test_can_write_and_read_block_with_different_sizes(tmp_path: PathLike):
     chunk_shape = (4, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2])
     chunk_start = 3
     block1 = DataSetBlock(
-        data=global_data[chunk_start:chunk_start+2, :, :],
+        data=global_data[chunk_start : chunk_start + 2, :, :],
         aux_data=AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0], dtype=np.float32)),
         global_shape=GLOBAL_SHAPE,
         chunk_shape=chunk_shape,
         block_start=0,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
     block2 = DataSetBlock(
-        data=global_data[chunk_start+2:chunk_start+2+2, :, :],
+        data=global_data[chunk_start + 2 : chunk_start + 2 + 2, :, :],
         aux_data=AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0], dtype=np.float32)),
         global_shape=GLOBAL_SHAPE,
         chunk_shape=chunk_shape,
         block_start=2,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
 
     writer.write_block(block1)
@@ -211,7 +218,9 @@ def test_can_write_and_read_block_with_different_sizes(tmp_path: PathLike):
 
     rblock = reader.read_block(0, 4)
 
-    np.testing.assert_array_equal(rblock.data, global_data[chunk_start:chunk_start+4, :, :])
+    np.testing.assert_array_equal(
+        rblock.data, global_data[chunk_start : chunk_start + 4, :, :]
+    )
 
 
 def test_writing_inconsistent_global_shapes_fails(tmp_path: PathLike):
@@ -226,7 +235,7 @@ def test_writing_inconsistent_global_shapes_fails(tmp_path: PathLike):
     )
     chunk_shape = (4, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2])
     chunk_start = 3
-    aux_data=AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0]+10, dtype=np.float32))
+    aux_data = AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0] + 10, dtype=np.float32))
     block1 = DataSetBlock(
         data=global_data[:2, :, :],
         aux_data=aux_data,
@@ -234,16 +243,16 @@ def test_writing_inconsistent_global_shapes_fails(tmp_path: PathLike):
         chunk_shape=chunk_shape,
         block_start=0,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
     block2 = DataSetBlock(
         data=global_data[:2, :, :],
         aux_data=aux_data,
-        global_shape=(GLOBAL_SHAPE[0]+1, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2]),
+        global_shape=(GLOBAL_SHAPE[0] + 1, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2]),
         chunk_shape=chunk_shape,
         block_start=2,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
 
     writer.write_block(block1)
@@ -251,6 +260,7 @@ def test_writing_inconsistent_global_shapes_fails(tmp_path: PathLike):
         writer.write_block(block2)
 
     assert "inconsistent shape" in str(e)
+
 
 def test_writing_inconsistent_chunk_shapes_fails(tmp_path: PathLike):
     writer = DataSetStoreWriter(
@@ -271,16 +281,16 @@ def test_writing_inconsistent_chunk_shapes_fails(tmp_path: PathLike):
         chunk_shape=chunk_shape,
         block_start=0,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
     block2 = DataSetBlock(
         data=global_data[2:2, :, :],
         aux_data=AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0], dtype=np.float32)),
         global_shape=GLOBAL_SHAPE,
-        chunk_shape=(chunk_shape[0]-1, chunk_shape[1], chunk_shape[2]),
+        chunk_shape=(chunk_shape[0] - 1, chunk_shape[1], chunk_shape[2]),
         block_start=2,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
 
     writer.write_block(block1)
@@ -288,6 +298,7 @@ def test_writing_inconsistent_chunk_shapes_fails(tmp_path: PathLike):
         writer.write_block(block2)
 
     assert "inconsistent shape" in str(e)
+
 
 def test_writing_inconsistent_global_index_fails(tmp_path: PathLike):
     writer = DataSetStoreWriter(
@@ -308,7 +319,7 @@ def test_writing_inconsistent_global_index_fails(tmp_path: PathLike):
         chunk_shape=chunk_shape,
         block_start=0,
         slicing_dim=0,
-        chunk_start=chunk_start
+        chunk_start=chunk_start,
     )
     block2 = DataSetBlock(
         data=global_data[2:2, :, :],
@@ -317,7 +328,7 @@ def test_writing_inconsistent_global_index_fails(tmp_path: PathLike):
         chunk_shape=chunk_shape,
         block_start=2,
         slicing_dim=0,
-        chunk_start=chunk_start+2
+        chunk_start=chunk_start + 2,
     )
 
     writer.write_block(block1)
@@ -325,7 +336,6 @@ def test_writing_inconsistent_global_index_fails(tmp_path: PathLike):
         writer.write_block(block2)
 
     assert "inconsistent shape" in str(e)
-
 
 
 def test_create_new_data_goes_to_file_on_memory_error(
@@ -350,8 +360,8 @@ def test_create_new_data_goes_to_file_on_memory_error(
         ANY,
         writer.comm,
     )
-    
-    
+
+
 def test_create_new_data_goes_to_file_on_memory_limit(
     mocker: MockerFixture, tmp_path: PathLike
 ):
@@ -359,8 +369,8 @@ def test_create_new_data_goes_to_file_on_memory_limit(
     data = np.ones(GLOBAL_SHAPE, dtype=np.float32)
     aux_data = AuxiliaryData(
         angles=np.ones(data.shape[0], dtype=np.float32),
-        darks=2.*np.ones((2, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2]), dtype=np.float32),
-        flats=1.*np.ones((2, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2]), dtype=np.float32),
+        darks=2.0 * np.ones((2, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2]), dtype=np.float32),
+        flats=1.0 * np.ones((2, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2]), dtype=np.float32),
     )
     block = DataSetBlock(
         data=data[0:2, :, :],
@@ -375,7 +385,7 @@ def test_create_new_data_goes_to_file_on_memory_limit(
         slicing_dim=0,
         comm=MPI.COMM_WORLD,
         temppath=tmp_path,
-        memory_limit_bytes=block.data.nbytes + 5  # only one block will fit in memory
+        memory_limit_bytes=block.data.nbytes + 5,  # only one block will fit in memory
     )
 
     createh5_mock = mocker.patch.object(
@@ -412,7 +422,10 @@ def test_calls_reslice(
 
 @pytest.mark.parametrize("file_based", [False, True])
 def test_reslice_single_block_single_process(
-    mocker: MockerFixture, dummy_block: DataSetBlock, tmp_path: PathLike, file_based: bool
+    mocker: MockerFixture,
+    dummy_block: DataSetBlock,
+    tmp_path: PathLike,
+    file_based: bool,
 ):
     writer = DataSetStoreWriter(
         slicing_dim=0,
@@ -490,7 +503,7 @@ def test_full_integration_with_reslice(
         global_shape=GLOBAL_DATA_SHAPE,
         block_start=0,
         chunk_start=chunk_start,
-        chunk_shape=(chunk_size, GLOBAL_DATA_SHAPE[1], GLOBAL_DATA_SHAPE[2])
+        chunk_shape=(chunk_size, GLOBAL_DATA_SHAPE[1], GLOBAL_DATA_SHAPE[2]),
     )
 
     writer = DataSetStoreWriter(
@@ -543,3 +556,85 @@ def test_full_integration_with_reslice(
                 :, GLOBAL_DATA_SHAPE[1] // 2 + 1 : GLOBAL_DATA_SHAPE[1] // 2 + 3, :
             ],
         )
+
+
+@pytest.mark.parametrize("file_based", [False, True])
+def test_can_write_blocks_with_padding_and_read(
+    mocker: MockerFixture, tmp_path: PathLike, file_based: bool
+):
+    writer = DataSetStoreWriter(
+        slicing_dim=0,
+        comm=MPI.COMM_WORLD,
+        temppath=tmp_path,
+    )
+
+    GLOBAL_SHAPE = (10, 10, 10)
+    global_data = np.arange(np.prod(GLOBAL_SHAPE), dtype=np.float32).reshape(
+        GLOBAL_SHAPE
+    )
+    padding = (2, 3)
+    core_chunk_shape = (4, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2])
+    chunk_shape = (
+        core_chunk_shape[0] + padding[0] + padding[1],
+        core_chunk_shape[1],
+        core_chunk_shape[2],
+    )
+    core_chunk_start = 3
+    chunk_start = core_chunk_start - padding[0]
+    b1shape = (2, GLOBAL_SHAPE[1], GLOBAL_SHAPE[2])
+    b1shape_padded = (b1shape[0] + padding[0] + padding[1], b1shape[1], b1shape[2])
+    b1data_padded = -np.ones(b1shape_padded, dtype=np.float32)
+    b1data_padded[padding[0] : padding[0] + 2, :, :] = global_data[
+        core_chunk_start : core_chunk_start + 2, :, :
+    ]
+    block1 = DataSetBlock(
+        data=b1data_padded,
+        aux_data=AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0], dtype=np.float32)),
+        global_shape=GLOBAL_SHAPE,
+        chunk_shape=chunk_shape,
+        block_start=-padding[0],
+        slicing_dim=0,
+        chunk_start=chunk_start,
+        padding=padding,
+    )
+    b2shape = b1shape
+    b2shape_padded = (b2shape[0] + padding[0] + padding[1], b2shape[1], b2shape[2])
+    b2data_padded = -np.ones(b2shape_padded, dtype=np.float32)
+    b2data_padded[padding[0] : padding[0] + 2, :, :] = global_data[
+        core_chunk_start + 2 : core_chunk_start + 2 + 2, :, :
+    ]
+    block2 = DataSetBlock(
+        data=b2data_padded,
+        aux_data=AuxiliaryData(angles=np.ones(GLOBAL_SHAPE[0], dtype=np.float32)),
+        global_shape=GLOBAL_SHAPE,
+        chunk_shape=chunk_shape,
+        block_start=2 - padding[0],
+        slicing_dim=0,
+        chunk_start=chunk_start,
+        padding=padding,
+    )
+
+    if file_based:
+        mocker.patch.object(writer, "_create_numpy_data", side_effect=MemoryError)
+    writer.write_block(block1)
+    writer.write_block(block2)
+
+    reader = writer.make_reader()
+
+    rblock1 = reader.read_block(0, 2)
+    rblock2 = reader.read_block(2, 2)
+
+    assert reader.global_shape == GLOBAL_SHAPE
+    assert reader.chunk_shape == core_chunk_shape
+    assert reader.global_index == (core_chunk_start, 0, 0)
+    assert reader.slicing_dim == 0
+
+    assert isinstance(rblock1.data, np.ndarray)
+    assert isinstance(rblock2.data, np.ndarray)
+
+    np.testing.assert_array_equal(
+        rblock1.data, global_data[core_chunk_start : core_chunk_start + 2, :, :]
+    )
+    np.testing.assert_array_equal(
+        rblock2.data, global_data[core_chunk_start + 2 : core_chunk_start + 2 + 2, :, :]
+    )


### PR DESCRIPTION
This PR adds support for padded data to the `DataSetStoreWriter` and `DataSetStoreReader` classes. In particular:

- writing blocks that include padding to the `DataSetStoreWriter` results on the padding slices to be dropped and only the core area to be written. 
- the `DataSetStoreWriter.make_reader` method gained a parameter for padding. The idea is that the task runner will create the reader this way for the next section, and it knows if that section needs padding and how much. 
- the `DataSetStoreReader` correctly handles padding, i.e.:
   - the reader properties `chunk_shape` and `global_index` are adapted to include the padding
   - when `read_block(start, length)` is called, it automatically generates a padded block. The parameters `start` and `length` are regarding the core area, but the shape of the returned block is `length + padding[0] + padding[1]`.
   - if the global data is stored in a file, the padding area is read directly from it, and the edges are extrapolated using the `_extrapolate_before` and `_extrapolate_after` methods
   - if the chunk's data is stored in memory, we need to ask the neighbour MPI processes for the padding area. This has been solved by actually including this area in `self._data` at construction time of the reader. The MPI exchange is done when the reader is constructed, so that the chunk + padding slices is available in `self._data`. This includes also the extrapolation at the boundaries. 

A set of tests confirms correct behaviour:
- file-based with padding: testing padding and extrapolation in center, front, back slices, and also if there is only one process (both edges are extrapolated)
- RAM-based with padding: testing MPI exchanges of neighbourhoods + boundary extrapolation
- both of the above with reslice, to make sure that the parameters and shapes are working after reslicing too.