### PR TITLE
Rearrange comm usage

### DIFF
--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -183,7 +183,7 @@ def run(
         _set_gpu_id(gpu_id)
 
         # Run the pipeline using Taskrunner, with temp dir or reslice dir
-        mon = make_monitors(monitor)
+        mon = make_monitors(monitor, comm)
         ctx: AbstractContextManager = nullcontext(reslice_dir)
         if reslice_dir is None:
             ctx = tempfile.TemporaryDirectory()
@@ -191,6 +191,7 @@ def run(
             runner = TaskRunner(
                 pipeline,
                 Path(tmp_dir),
+                comm,
                 monitor=mon,
                 memory_limit_bytes=memory_limit,
             )

--- a/httomo/data/mpiutil.py
+++ b/httomo/data/mpiutil.py
@@ -6,8 +6,6 @@ from mpi4py import MPI
 
 __all__ = ["alltoall"]
 
-comm = MPI.COMM_WORLD
-local_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
 
 # add this here so that we can mock it in the tests
 _mpi_max_elements = 2**31

--- a/httomo/data/mpiutil.py
+++ b/httomo/data/mpiutil.py
@@ -6,15 +6,13 @@ try:
     from mpi4py import MPI
 
     comsize = MPI.COMM_WORLD.__sizeof__()
-    enabled = comsize > 1
 except ImportError:
-    enabled = False
+    pass
 
-__all__ = ["enabled", "alltoall"]
+__all__ = ["alltoall"]
 
-if enabled:
-    comm = MPI.COMM_WORLD
-    local_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
+comm = MPI.COMM_WORLD
+local_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
 
 # add this here so that we can mock it in the tests
 _mpi_max_elements = 2**31

--- a/httomo/data/mpiutil.py
+++ b/httomo/data/mpiutil.py
@@ -10,20 +10,16 @@ try:
 except ImportError:
     enabled = False
 
-__all__ = ["enabled", "size", "rank", "local_size", "local_rank", "alltoall"]
+__all__ = ["enabled", "size", "rank", "alltoall"]
 
 if enabled:
     comm = MPI.COMM_WORLD
     size = comm.size
     rank = comm.rank
     local_comm = comm.Split_type(MPI.COMM_TYPE_SHARED)
-    local_size = local_comm.size
-    local_rank = local_comm.rank
 else:
     size = 1
     rank = 0
-    local_size = 1
-    local_rank = 0
 
 # add this here so that we can mock it in the tests
 _mpi_max_elements = 2**31

--- a/httomo/data/mpiutil.py
+++ b/httomo/data/mpiutil.py
@@ -1,13 +1,8 @@
 from typing import List
 
 import numpy as np
+from mpi4py import MPI
 
-try:
-    from mpi4py import MPI
-
-    comsize = MPI.COMM_WORLD.__sizeof__()
-except ImportError:
-    pass
 
 __all__ = ["alltoall"]
 

--- a/httomo/method_wrappers/generic.py
+++ b/httomo/method_wrappers/generic.py
@@ -1,7 +1,6 @@
 import httomo.globals
 from httomo.block_interfaces import T, Block
-from httomo.data import mpiutil
-from httomo.runner.gpu_utils import gpumem_cleanup
+from httomo.runner.gpu_utils import get_gpu_id, gpumem_cleanup
 from httomo.runner.method_wrapper import (
     GpuTimeInfo,
     MethodParameterDictType,
@@ -126,9 +125,8 @@ class GenericMethodWrapper(MethodWrapper):
         self._gpu_time_info = GpuTimeInfo()
 
         if gpu_enabled:
-            self._num_gpus = xp.cuda.runtime.getDeviceCount()
             _id = httomo.globals.gpu_id
-            self._gpu_id = mpiutil.local_rank % self._num_gpus if _id == -1 else _id
+            self._gpu_id = get_gpu_id() if _id == -1 else _id
 
     @property
     def comm(self) -> Comm:

--- a/httomo/monitors/__init__.py
+++ b/httomo/monitors/__init__.py
@@ -1,4 +1,7 @@
 from typing import Dict, List, Optional
+
+from mpi4py import MPI
+
 from httomo.monitors.aggregate import AggregateMonitoring
 from httomo.monitors.benchmark import BenchmarkMonitoring
 from httomo.monitors.summary import SummaryMonitor
@@ -10,7 +13,10 @@ MONITORS_MAP = {
     "summary": SummaryMonitor
 }
 
-def make_monitors(monitor_descriptors: List[str]) -> Optional[MonitoringInterface]:
+def make_monitors(
+    monitor_descriptors: List[str],
+    comm: MPI.Comm,
+) -> Optional[MonitoringInterface]:
     if len(monitor_descriptors) == 0:
         return None
     
@@ -18,6 +24,6 @@ def make_monitors(monitor_descriptors: List[str]) -> Optional[MonitoringInterfac
     for descriptor in monitor_descriptors:
         if descriptor not in MONITORS_MAP:
             raise ValueError(f"Unknown monitor '{descriptor}'. Please choose one of {MONITORS_MAP.keys()}")
-        monitors.append(MONITORS_MAP[descriptor]())
+        monitors.append(MONITORS_MAP[descriptor](comm))
         
     return AggregateMonitoring(monitors)

--- a/httomo/monitors/benchmark.py
+++ b/httomo/monitors/benchmark.py
@@ -6,10 +6,10 @@ from collections import OrderedDict
 
 
 class BenchmarkMonitoring(MonitoringInterface):
-    def __init__(self) -> None:
+    def __init__(self, comm: MPI.Comm) -> None:
+        self._comm = comm
         self._data: List[Dict[str, str]] = []
         self._total = 0.0
-        self._comm = MPI.COMM_WORLD
 
     def report_method_block(
         self,

--- a/httomo/monitors/summary.py
+++ b/httomo/monitors/summary.py
@@ -4,7 +4,8 @@ from httomo.runner.monitoring_interface import MonitoringInterface
 
 
 class SummaryMonitor(MonitoringInterface):
-    def __init__(self) -> None:
+    def __init__(self, comm: MPI.Comm) -> None:
+        self._comm = comm
         self._methods_cpu = 0.0
         self._methods_gpu = 0.0
         self._methods: Dict[str, float] = dict()
@@ -14,7 +15,6 @@ class SummaryMonitor(MonitoringInterface):
         self._sinks = 0.0
         self._total = 0.0
         self._total_agg = 0.0
-        self._comm = MPI.COMM_WORLD
     
     def report_method_block(
         self,

--- a/httomo/runner/gpu_utils.py
+++ b/httomo/runner/gpu_utils.py
@@ -1,3 +1,5 @@
+from mpi4py import MPI
+
 from httomo.utils import gpu_enabled, xp
 
 
@@ -23,3 +25,12 @@ def get_available_gpu_memory(safety_margin_percent: float = 10.0) -> int:
     except:
         return int(100e9)  # arbitrarily high number - only used if GPU isn't available
 
+
+def get_gpu_id() -> int:
+    """
+    Get the ID of the specific GPU on the machine that the process should use
+    """
+    num_gpus = xp.cuda.runtime.getDeviceCount()
+    global_comm = MPI.COMM_WORLD
+    local_comm = global_comm.Split_type(MPI.COMM_TYPE_SHARED)
+    return local_comm.rank % num_gpus

--- a/httomo/runner/gpu_utils.py
+++ b/httomo/runner/gpu_utils.py
@@ -14,9 +14,8 @@ def gpumem_cleanup():
 def get_available_gpu_memory(safety_margin_percent: float = 10.0) -> int:
     try:
         import cupy as cp
-        from httomo.data.mpiutil import local_rank
 
-        dev = cp.cuda.Device(local_rank)
+        dev = cp.cuda.Device(get_gpu_id())
         with dev:
             gpumem_cleanup()
             pool = cp.get_default_memory_pool()

--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -40,12 +40,13 @@ class TaskRunner:
         self,
         pipeline: Pipeline,
         reslice_dir: os.PathLike,
+        comm: MPI.Comm,
         memory_limit_bytes: int = 0,
         monitor: Optional[MonitoringInterface] = None,
     ):
         self.pipeline = pipeline
         self.reslice_dir = reslice_dir
-        self.comm = MPI.COMM_WORLD
+        self.comm = comm
         self.monitor = monitor
 
         self.side_outputs: Dict[str, Any] = dict()

--- a/httomo/transform_layer.py
+++ b/httomo/transform_layer.py
@@ -11,8 +11,8 @@ import httomo
 class TransformLayer:
     def __init__(
         self,
+        comm: MPI.Comm,
         repo=MethodDatabaseRepository(),
-        comm: MPI.Comm = MPI.COMM_WORLD,
         save_all=False,
         out_dir: Optional[os.PathLike] = None,
     ):

--- a/tests/method_wrappers/test_generic.py
+++ b/tests/method_wrappers/test_generic.py
@@ -639,3 +639,73 @@ def test_generic_calculate_output_dims_no_change(mocker: MockerFixture):
     dims = wrp.calculate_output_dims((10, 10))
 
     assert dims == (10, 10)
+
+
+def test_generic_execute_uses_comm_passed_to_constructor(
+    mocker: MockerFixture,
+    dummy_block: DataSetBlock,
+):
+    # Define mock global comm, to be used in place of `MPI.COMM_WORLD` in the code to be tested
+    global_comm_mock = mocker.create_autospec(MPI.Comm)
+    global_comm_mock.size = 8
+    global_comm_mock.rank = 0
+
+    # Patch `httomo.runner.gpu_utils` import of `MPI.COMM_WORLD` to be the mock global
+    # communicator object defined
+    mocker.patch("httomo.runner.gpu_utils.MPI.COMM_WORLD", global_comm_mock)
+
+    # Define spy on mock global communicator's `bcast()` method, for later assertions that its
+    # `bcast()` method is never called.
+    #
+    # The fact that its `bcast()` method should never be called is used as a proxy/marker that
+    # the global communicator is never used in method execution, only the communicator passed
+    # into the method wrapper's constructor should be used in method execution.
+    global_comm_bcast_spy = mocker.patch.object(target=global_comm_mock, attribute="bcast")
+
+    # Define mock comm object to pass into method wrapper constructor
+    passed_in_mock_comm = mocker.create_autospec(MPI.Comm)
+    passed_in_mock_comm.size = 1
+    passed_in_mock_comm.rank = 0
+
+    # Define spy on mock communicator passed into method wrapper constructor, for later
+    # assertions that its `bcast()` method is only called when the method is executed
+    passed_in_mock_comm_bcast_spy = mocker.patch.object(
+        target=passed_in_mock_comm,
+        attribute="bcast",
+    )
+
+    # Define dummy method function which has a `comm` parameter. This will make the method
+    # wrapper pass in its `self.comm` to the method function. This communicator is the
+    # communicator that is passed into the method wrapper constructor. Therefore, the
+    # communicator in the method function *should* be the communicator that is passed into the
+    # method wrapper's constructor, and *not* the global communicator.
+    #
+    # Suppose the communicator given to the method function is used in some manner (say, the
+    # `bcast()` method is called) during the method execution. Then, a spy on the `bcast()`
+    # method can be used to verify if the communicator being used for method execution is the
+    # one passed into the method wrapper's constructor and *not* the global communicator.
+    class FakeModule:
+        def test_method(data, comm):
+            comm.bcast(1, root=0)
+            return data
+
+    mocker.patch("importlib.import_module", return_value=FakeModule)
+
+    wrp = make_method_wrapper(
+        make_mock_repo(mocker),
+        "mocked_module_path",
+        "test_method",
+        comm=passed_in_mock_comm,
+    )
+
+    # Run `execute()` method, which should trigger the dummy method function defined earlier,
+    # that will access the communicator given to it by the method wrapper (which will be the
+    # communicator that was passed into the method wrapper constructor)
+    #
+    # The global communicator should never be executed, and the communicator passed into the
+    # method wrapper constructor should only be executed once when the method is executed.
+    global_comm_bcast_spy.assert_not_called()
+    passed_in_mock_comm_bcast_spy.assert_not_called()
+    wrp.execute(dummy_block)
+    global_comm_bcast_spy.assert_not_called()
+    passed_in_mock_comm_bcast_spy.assert_called_once()

--- a/tests/monitors/test_aggregate.py
+++ b/tests/monitors/test_aggregate.py
@@ -1,6 +1,9 @@
 from io import StringIO
+
 import pytest
+from mpi4py import MPI
 from pytest_mock import MockerFixture
+
 from httomo.monitors import make_monitors
 from httomo.monitors.aggregate import AggregateMonitoring
 
@@ -72,7 +75,7 @@ def test_make_monitors_2(mocker: MockerFixture):
         "httomo.monitors.MONITORS_MAP", {"m1": moncls1, "m2": moncls2, "m3": moncls3}
     )
 
-    mon = make_monitors(["m1", "m2"])
+    mon = make_monitors(["m1", "m2"], MPI.COMM_WORLD)
     assert isinstance(mon, AggregateMonitoring)
     assert len(mon._monitors) == 2
     moncls1.assert_called_once()
@@ -86,10 +89,10 @@ def test_make_monitors_unknown(mocker: MockerFixture):
     mocker.patch("httomo.monitors.MONITORS_MAP", {})
 
     with pytest.raises(ValueError) as e:
-        make_monitors(["m1"])
+        make_monitors(["m1"], MPI.COMM_WORLD)
 
     assert "Unknown monitor 'm1'" in str(e)
 
 
 def test_make_monitors_empty():
-    assert make_monitors([]) is None
+    assert make_monitors([], MPI.COMM_WORLD) is None

--- a/tests/monitors/test_benchmark.py
+++ b/tests/monitors/test_benchmark.py
@@ -6,7 +6,7 @@ from httomo.monitors.benchmark import BenchmarkMonitoring
 
 
 def test_benchmark_monitor_records_and_displays_data():
-    mon = BenchmarkMonitoring()
+    mon = BenchmarkMonitoring(MPI.COMM_WORLD)
     mon.report_method_block(
         "method1", "module", "task", 0, (1, 2, 3), (0, 0, 0), (10, 0, 0), 42.0, 2.0, 0.1, 0.2
     )
@@ -60,7 +60,7 @@ def test_benchmark_monitor_records_and_displays_data():
 )
 def test_summary_monitor_records_and_displays_data_mpi():
     comm = MPI.COMM_WORLD
-    mon = BenchmarkMonitoring()
+    mon = BenchmarkMonitoring(comm)
     # everything gets reported twice - once in each process - and the write_results should aggregate
     # in process 0
     mon.report_method_block(

--- a/tests/monitors/test_summary.py
+++ b/tests/monitors/test_summary.py
@@ -6,7 +6,7 @@ from httomo.monitors.summary import SummaryMonitor
 
 
 def test_summary_monitor_records_and_displays_data():
-    mon = SummaryMonitor()
+    mon = SummaryMonitor(MPI.COMM_WORLD)
     mon.report_method_block(
         "method1", "module", "task", 0, (1, 2, 3), (0, 0, 0), (10, 0, 0), 42.0, 2.0
     )
@@ -52,7 +52,7 @@ def test_summary_monitor_records_and_displays_data():
 def test_summary_monitor_records_and_displays_data_mpi():
 
     comm = MPI.COMM_WORLD
-    mon = SummaryMonitor()
+    mon = SummaryMonitor(comm)
     # everything gets reported twice - once in each process - and the write_results should aggregate
     # in process 0
     mon.report_method_block(

--- a/tests/runner/test_gpu_utils.py
+++ b/tests/runner/test_gpu_utils.py
@@ -2,7 +2,6 @@ import pytest
 from mpi4py import MPI
 from pytest_mock import MockerFixture
 
-from httomo.data.mpiutil import local_rank
 from httomo.runner.gpu_utils import get_available_gpu_memory, get_gpu_id
 from httomo.utils import xp, gpu_enabled
 
@@ -15,7 +14,7 @@ def test_get_available_memory():
     mem = get_available_gpu_memory(10.0)
 
     assert mem > 0
-    assert mem <= 0.9 * xp.cuda.Device(local_rank).mem_info[0]
+    assert mem <= 0.9 * xp.cuda.Device(get_gpu_id()).mem_info[0]
 
 
 

--- a/tests/runner/test_gpu_utils.py
+++ b/tests/runner/test_gpu_utils.py
@@ -1,7 +1,9 @@
 import pytest
+from mpi4py import MPI
 from pytest_mock import MockerFixture
+
 from httomo.data.mpiutil import local_rank
-from httomo.runner.gpu_utils import get_available_gpu_memory
+from httomo.runner.gpu_utils import get_available_gpu_memory, get_gpu_id
 from httomo.utils import xp, gpu_enabled
 
 
@@ -24,3 +26,55 @@ def test_get_available_memory_cpu(mocker: MockerFixture):
         mocker.patch("cupy.cuda.Device", side_effect=ImportError("can't use cupy"))
     # greater 10GB
     assert get_available_gpu_memory() > 10e9
+
+
+@pytest.mark.parametrize(
+    "nodes, gpus_per_node, global_rank, local_rank",
+    [
+        (1, 4, 0, 0),
+        (1, 4, 2, 2),
+        (1, 2, 1, 1),
+        (2, 4, 0, 0),
+        (2, 4, 6, 2),
+        (2, 2, 1, 1),
+        (2, 2, 3, 1),
+    ],
+    ids=[
+        "single-node-4gpus-per-node-rank-0",
+        "single-node-4gpus-per-node-rank-2",
+        "single-node-2gpus-per-node-rank-1",
+        "multi-node-4gpus-per-node-rank-0",
+        "multi-node-4gpus-per-node-rank-6",
+        "multi-node-2gpus-per-node-rank-1",
+        "multi-node-2gpus-per-node-rank-3",
+    ],
+)
+def test_get_gpu_id(
+    mocker: MockerFixture,
+    nodes: int,
+    gpus_per_node: int,
+    global_rank: int,
+    local_rank: int,
+):
+    # Mock global communicator object to reflect the number of nodes and gpus per node
+    mock_global_comm = mocker.create_autospec(MPI.Comm)
+    mock_global_comm.size = nodes * gpus_per_node
+    mock_global_comm.rank = global_rank
+    # Mock "local" communicator object (the comm local to a single node) to reflect the number
+    # of gpus per node
+    mock_local_comm = mocker.create_autospec(MPI.Comm)
+    mock_local_comm.size = gpus_per_node
+    mock_local_comm.rank = local_rank
+    # Patch mock global comm to return mock local comm when the global comm is "split"
+    mocker.patch.object(mock_global_comm, "Split_type", return_value=mock_local_comm)
+
+    # Patch `httomo.runner.gpu_utils` import of `MPI.COMM_WORLD` to be the mock global
+    # communicator object defined
+    mocker.patch("httomo.runner.gpu_utils.MPI.COMM_WORLD", mock_global_comm)
+    # Patch `cupy.cuda.runtime.getDeviceCount()` to return tbe desired number of GPUs that the
+    # parametrisation of the test is wanting to check
+    mocker.patch("cupy.cuda.runtime.getDeviceCount", return_value=gpus_per_node)
+
+    # Check that the GPU ID returned is the expected GPU ID
+    gpu_id = get_gpu_id()
+    assert gpu_id == local_rank

--- a/tests/test_mpiutil.py
+++ b/tests/test_mpiutil.py
@@ -12,32 +12,6 @@ def test_global_ranks():
 
 
 @pytest.mark.mpi
-def test_local_ranks():
-    # build reference local rank using MPI hostname
-    comm = MPI.COMM_WORLD
-    hosts_ranks = {}
-    host = MPI.Get_processor_name()
-    rank_host = {}
-    ret = comm.gather({comm.rank: host})
-    if comm.rank == 0:
-        for d in ret:
-            rank_host.update(d)
-    for k, v in rank_host.items():
-        if v not in hosts_ranks:
-            hosts_ranks[v] = [k]
-        else:
-            hosts_ranks[v].append(k)
-
-    hosts_ranks = comm.bcast(hosts_ranks)
-    rank_local = hosts_ranks[host].index(comm.rank)
-    size_local = len(hosts_ranks[host])
-    del rank_host
-
-    assert mpiutil.local_rank == rank_local
-    assert mpiutil.local_size == size_local
-
-
-@pytest.mark.mpi
 def test_all_to_all():
     data = [
         np.ones((5, 5, 5), dtype=np.uint16) * mpiutil.rank for _ in range(mpiutil.size)

--- a/tests/test_mpiutil.py
+++ b/tests/test_mpiutil.py
@@ -2,21 +2,16 @@ import numpy as np
 import pytest
 from mpi4py import MPI
 
-from httomo.data import mpiutil
-
-
-@pytest.mark.mpi
-def test_global_ranks():
-    assert mpiutil.rank == MPI.COMM_WORLD.rank
-    assert mpiutil.size == MPI.COMM_WORLD.size
+from httomo.data.mpiutil import alltoall
 
 
 @pytest.mark.mpi
 def test_all_to_all():
+    comm = MPI.COMM_WORLD
     data = [
-        np.ones((5, 5, 5), dtype=np.uint16) * mpiutil.rank for _ in range(mpiutil.size)
+        np.ones((5, 5, 5), dtype=np.uint16) * comm.rank for _ in range(comm.size)
     ]
-    rec = mpiutil.alltoall(data)
+    rec = alltoall(data, comm)
 
-    expected = [np.ones((5, 5, 5), dtype=np.uint16) * r for r in range(mpiutil.size)]
+    expected = [np.ones((5, 5, 5), dtype=np.uint16) * r for r in range(comm.size)]
     np.testing.assert_array_equal(expected, rec)

--- a/tests/test_transform_layer.py
+++ b/tests/test_transform_layer.py
@@ -22,7 +22,7 @@ def test_insert_save_methods(mocker: MockerFixture, tmp_path: Path):
             make_test_method(mocker, method_name="m2", save_result=False),
         ],
     )
-    trans = TransformLayer(repo, comm=comm, save_all=False, out_dir=tmp_path)
+    trans = TransformLayer(comm, repo=repo, save_all=False, out_dir=tmp_path)
     pipeline = trans.insert_save_methods(pipeline)
 
     assert len(pipeline) == 3
@@ -44,7 +44,7 @@ def test_insert_save_methods_save_all(mocker: MockerFixture, tmp_path: Path):
             make_test_method(mocker, method_name="m2", save_result=False, task_id="t2"),
         ],
     )
-    trans = TransformLayer(repo, comm=comm, save_all=True, out_dir=tmp_path)
+    trans = TransformLayer(comm, repo=repo, save_all=True, out_dir=tmp_path)
     pipeline = trans.insert_save_methods(pipeline)
 
     assert len(pipeline) == 4
@@ -73,7 +73,7 @@ def test_insert_save_methods_does_not_save_for_save_to_images(
             ),
         ],
     )
-    trans = TransformLayer(repo, comm=comm, save_all=False, out_dir=tmp_path)
+    trans = TransformLayer(comm, repo=repo, save_all=False, out_dir=tmp_path)
     pipeline = trans.insert_save_methods(pipeline)
 
     assert len(pipeline) == 2
@@ -95,7 +95,7 @@ def test_insert_save_methods_does_nothing_if_no_save(
             make_test_method(mocker, method_name="m2", save_result=False, task_id="t2"),
         ],
     )
-    trans = TransformLayer(repo, comm=comm, save_all=False, out_dir=tmp_path)
+    trans = TransformLayer(comm, repo=repo, save_all=False, out_dir=tmp_path)
     pipeline = trans.insert_save_methods(pipeline)
 
     assert len(pipeline) == 2
@@ -134,7 +134,7 @@ def test_insert_data_reducer(mocker: MockerFixture, tmp_path: Path):
             make_test_method(mocker, method_name="normalize", save_result=False),
         ],
     )
-    trans = TransformLayer(repo, comm=comm, save_all=False, out_dir=tmp_path)
+    trans = TransformLayer(comm, repo=repo, save_all=False, out_dir=tmp_path)
     pipeline = trans.insert_data_reducer(pipeline)
 
     assert len(pipeline) == 3


### PR DESCRIPTION
Various small changes to how a communicator object is used by httomo objects:
- hardcoded communicator objects in constructor logic are now passed in as a constructor parameter
- method wrappers are verified to only use communicator passed into the constructor for method execution (global communicator usage is limited to getting the GPU ID for a process)
- modify custom `alltoall()` to have communicator passed-in, instead of hardcoding usage of `MPI.COMM_WORLD`
- remove global vars relating to MPI in `mpiutil.py`
- define communicator objects in CLI, and pass them to the runner objects