### PR TITLE
Add padding calculators functions to wrapper and runner

### DIFF
--- a/httomo/method_wrappers/generic.py
+++ b/httomo/method_wrappers/generic.py
@@ -375,6 +375,12 @@ class GenericMethodWrapper(MethodWrapper):
 
         return non_slice_dims_shape
 
+    def calculate_padding(self) -> Tuple[int, int]:
+        """Calculate the padding required by the method"""
+        if self.padding:
+            return self._query.calculate_padding(**self.config_params)
+        return (0, 0)
+
     def calculate_max_slices(
         self,
         data_dtype: np.dtype,

--- a/httomo/runner/method_wrapper.py
+++ b/httomo/runner/method_wrapper.py
@@ -164,6 +164,9 @@ class MethodWrapper(Protocol):
         """Calculate the dimensions of the output for this method"""
         ... # pragma: nocover
         
+    def calculate_padding(self) -> Tuple[int, int]:
+        """Calculate the padding required by the method"""
+        ... # pragma: nocover
 
     def calculate_max_slices(
         self,
@@ -180,10 +183,3 @@ class MethodWrapper(Protocol):
         something persists afterwards.
         """
         ... # pragma: nocover
-        
-        
-
-
-
-
-

--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -1,7 +1,7 @@
 from itertools import islice
 import logging
 import time
-from typing import Any, Dict, Literal, Optional, List, Union
+from typing import Any, Dict, Literal, Optional, List, Tuple, Union
 import os
 
 import tqdm
@@ -342,3 +342,11 @@ class TaskRunner:
             non_slice_dims_shape = output_dims
 
         section.max_slices = min(max_slices_methods)
+
+    def determine_section_padding(self, section: Section) -> Tuple[int, int]:
+        # NOTE: Assumes that only one method with padding will be in a section, which is
+        # consistent with the assumptions made by `section.sectionizer()`
+        for method in section.methods:
+            if method.padding:
+                return method.calculate_padding()
+        return (0, 0)

--- a/tests/runner/test_task_runner.py
+++ b/tests/runner/test_task_runner.py
@@ -1,5 +1,5 @@
 from os import PathLike
-from typing import List
+from typing import List, Tuple
 from unittest.mock import ANY, call
 
 import pytest
@@ -15,8 +15,13 @@ from httomo.runner.monitoring_interface import MonitoringInterface
 from httomo.runner.output_ref import OutputRef
 from httomo.runner.pipeline import Pipeline
 from httomo.runner.section import Section, sectionize
-from httomo.runner.task_runner import TaskRunner
-from httomo.utils import Pattern, xp, gpu_enabled
+from httomo.runner.task_runner import TaskRunner, calculate_next_chunk_shape
+from httomo.utils import (
+    Pattern,
+    make_3d_shape_from_shape,
+    xp,
+    gpu_enabled,
+)
 from httomo.runner.method_wrapper import GpuTimeInfo, MethodWrapper
 from ..testing_utils import make_test_loader, make_test_method
 
@@ -541,3 +546,58 @@ def test_determine_section_padding_one_padding_method_and_other_methods_in_secti
 
     section_padding = runner.determine_section_padding(sections[0])
     assert section_padding == PADDING
+
+
+@pytest.mark.parametrize(
+    "nprocs, rank, next_section_slicing_dim, next_section_padding",
+    [
+        (2, 1, 0, (0, 0)),
+        (2, 1, 0, (3, 5)),
+        (2, 1, 1, (0, 0)),
+        (2, 1, 1, (3, 5)),
+        (4, 2, 0, (0, 0)),
+        (4, 2, 0, (3, 5)),
+        (4, 2, 1, (0, 0)),
+        (4, 2, 1, (3, 5)),
+    ],
+    ids=[
+        "2procs-proj-to-proj_unpadded",
+        "2procs-proj-to-proj_padded",
+        "2procs-proj-to-sino_unpadded",
+        "2procs-proj-to-sino_padded",
+        "4procs-proj-to-proj_unpadded",
+        "4procs-proj-to-proj_padded",
+        "4procs-proj-to-sino_unpadded",
+        "4procs-proj-to-sino_padded",
+    ],
+)
+def test_calculate_next_chunk_shape(
+    nprocs: int,
+    rank: int,
+    next_section_slicing_dim: int,
+    next_section_padding: Tuple[int, int],
+    mocker: MockerFixture,
+):
+    GLOBAL_SHAPE = (1801, 2160, 2560)
+
+    # Define mock communicator that reflects the desired data splitting/distribution to be
+    # tested
+    mock_global_comm = mocker.create_autospec(spec=MPI.Comm, size=nprocs, rank=rank)
+
+    # The chunk shape for the next section should reflect the padding needed for that section
+    expected_next_chunk_shape: List[int] = list(GLOBAL_SHAPE)
+    start = round(GLOBAL_SHAPE[next_section_slicing_dim] / nprocs * rank)
+    stop = round(GLOBAL_SHAPE[next_section_slicing_dim] / nprocs * (rank + 1))
+    slicing_dim_len = stop - start
+    expected_next_chunk_shape[next_section_slicing_dim] = (
+        slicing_dim_len + next_section_padding[0] + next_section_padding[1]
+    )
+    next_section_chunk_shape = calculate_next_chunk_shape(
+        comm=mock_global_comm,
+        global_shape=GLOBAL_SHAPE,
+        next_section_slicing_dim=next_section_slicing_dim,
+        next_section_padding=next_section_padding,
+    )
+    assert next_section_chunk_shape == make_3d_shape_from_shape(
+        expected_next_chunk_shape
+    )


### PR DESCRIPTION
This adds a few functions that calculate padding for different objects:
- method for wrapper to calculate padding via supporting functions in methods database
- method for runner to calculate padding of a section
- standalone function for runner to calculate the chunk shape (including padding) for the next section
  - this was made a standalone function instead of a method to make testing easier (needing to create a `TaskRunner` object simply to calculate different chunks shapes is overkill in my opinion, and parametrisation of the logic is much easier when not needing to generate different `Pipeline` objects to create a list of `Section` objects using a runner object)