### PR TITLE
Enable `StandardTomoLoader` to load padded blocks

### DIFF
--- a/httomo/data/padding.py
+++ b/httomo/data/padding.py
@@ -6,6 +6,9 @@ import numpy as np
 from httomo.preview import PreviewConfig
 
 
+DIMS = [0, 1, 2]
+
+
 def extrapolate_before(
     global_data: h5py.Dataset | np.ndarray,
     block_data: np.ndarray,
@@ -24,7 +27,6 @@ def extrapolate_before(
     if slices == 0:
         return
 
-    DIMS = [0, 1, 2]
     non_slicing_dims = tuple(set(DIMS) - set([dim]))
     slices_wrt = [slice(None), slice(None), slice(None)]
     slices_wrt[dim] = slice(slices)
@@ -53,6 +55,7 @@ def extrapolate_after(
     slices: int,
     dim: int,
     offset: int = 0,
+    preview_config: Optional[PreviewConfig] = None,
 ):
     """
     Read the required "after" padded area for a block into the given numpy array that
@@ -63,12 +66,24 @@ def extrapolate_after(
     """
     if slices == 0:
         return
+
+    non_slicing_dims = tuple(set(DIMS) - set([dim]))
     slices_wrt = [slice(None), slice(None), slice(None)]
     slices_wrt[dim] = slice(block_data.shape[dim] - slices, block_data.shape[dim])
+
     slices_read = [slice(None), slice(None), slice(None)]
-    slices_read[dim] = slice(
-        global_data.shape[dim] - 1 - offset, global_data.shape[dim] - offset
-    )
+    if preview_config is None:
+        slices_read[dim] = slice(
+            global_data.shape[dim] - 1 - offset, global_data.shape[dim] - offset
+        )
+    else:
+        slices_read[dim] = slice(preview_config[dim].stop - 1, preview_config[dim].stop)
+        for non_slicing_dim in non_slicing_dims:
+            slices_read[non_slicing_dim] = slice(
+                preview_config[non_slicing_dim].start,
+                preview_config[non_slicing_dim].stop,
+            )
+
     block_data[slices_wrt[0], slices_wrt[1], slices_wrt[2]] = global_data[
         slices_read[0], slices_read[1], slices_read[2]
     ]

--- a/httomo/data/padding.py
+++ b/httomo/data/padding.py
@@ -1,5 +1,9 @@
+from typing import Optional
+
 import h5py
 import numpy as np
+
+from httomo.preview import PreviewConfig
 
 
 def extrapolate_before(
@@ -8,6 +12,7 @@ def extrapolate_before(
     slices: int,
     dim: int,
     offset: int = 0,
+    preview_config: Optional[PreviewConfig] = None,
 ) -> None:
     """
     Read the required "before" padded area for a block into the given numpy array that
@@ -18,10 +23,25 @@ def extrapolate_before(
     """
     if slices == 0:
         return
+
+    DIMS = [0, 1, 2]
+    non_slicing_dims = tuple(set(DIMS) - set([dim]))
     slices_wrt = [slice(None), slice(None), slice(None)]
     slices_wrt[dim] = slice(slices)
+
     slices_read = [slice(None), slice(None), slice(None)]
-    slices_read[dim] = slice(offset, offset + 1)
+    if preview_config is None:
+        slices_read[dim] = slice(offset, offset + 1)
+    else:
+        slices_read[dim] = slice(
+            preview_config[dim].start, preview_config[dim].start + 1
+        )
+        for non_slicing_dim in non_slicing_dims:
+            slices_read[non_slicing_dim] = slice(
+                preview_config[non_slicing_dim].start,
+                preview_config[non_slicing_dim].stop,
+            )
+
     block_data[slices_wrt[0], slices_wrt[1], slices_wrt[2]] = global_data[
         slices_read[0], slices_read[1], slices_read[2]
     ]

--- a/httomo/data/padding.py
+++ b/httomo/data/padding.py
@@ -1,0 +1,54 @@
+import h5py
+import numpy as np
+
+
+def extrapolate_before(
+    global_data: h5py.Dataset | np.ndarray,
+    block_data: np.ndarray,
+    slices: int,
+    dim: int,
+    offset: int = 0,
+) -> None:
+    """
+    Read the required "before" padded area for a block into the given numpy array that
+    represents the block.
+
+    NOTE: Currently performs "edge" padding as is understood in the padding terminology of
+    `np.pad()`
+    """
+    if slices == 0:
+        return
+    slices_wrt = [slice(None), slice(None), slice(None)]
+    slices_wrt[dim] = slice(slices)
+    slices_read = [slice(None), slice(None), slice(None)]
+    slices_read[dim] = slice(offset, offset + 1)
+    block_data[slices_wrt[0], slices_wrt[1], slices_wrt[2]] = global_data[
+        slices_read[0], slices_read[1], slices_read[2]
+    ]
+
+
+def extrapolate_after(
+    global_data: h5py.Dataset | np.ndarray,
+    block_data: np.ndarray,
+    slices: int,
+    dim: int,
+    offset: int = 0,
+):
+    """
+    Read the required "after" padded area for a block into the given numpy array that
+    represents the block.
+
+    NOTE: Currently performs "edge" padding as is understood in the padding terminology of
+    `np.pad()`
+    """
+    if slices == 0:
+        return
+    slices_wrt = [slice(None), slice(None), slice(None)]
+    slices_wrt[dim] = slice(block_data.shape[dim] - slices, block_data.shape[dim])
+    slices_read = [slice(None), slice(None), slice(None)]
+    slices_read[dim] = slice(
+        global_data.shape[dim] - 1 - offset, global_data.shape[dim] - offset
+    )
+    block_data[slices_wrt[0], slices_wrt[1], slices_wrt[2]] = global_data[
+        slices_read[0], slices_read[1], slices_read[2]
+    ]

--- a/httomo/loaders/standard_tomo_loader.py
+++ b/httomo/loaders/standard_tomo_loader.py
@@ -181,7 +181,7 @@ class StandardTomoLoader(DataSetSource):
                 block_data,
                 self._padding[0],
                 self._slicing_dim,
-                offset=self._data_offset[self._slicing_dim],
+                preview_config=self._preview.config,
             )
             before_extended_read = False
 

--- a/httomo/loaders/standard_tomo_loader.py
+++ b/httomo/loaders/standard_tomo_loader.py
@@ -189,17 +189,12 @@ class StandardTomoLoader(DataSetSource):
             start_idx[self._slicing_dim] + block_shape[self._slicing_dim]
             > self.global_shape[self._slicing_dim]
         ):
-            proj_data_end = (
-                self._data_offset[self._slicing_dim]
-                + self.global_shape[self._slicing_dim]
-            )
-            offset = self._data.shape[self._slicing_dim] - proj_data_end
             extrapolate_after(
                 self._data,
                 block_data,
                 self._padding[1],
                 self._slicing_dim,
-                offset=offset,
+                preview_config=self._preview.config,
             )
             after_extended_read = False
 

--- a/httomo/loaders/standard_tomo_loader.py
+++ b/httomo/loaders/standard_tomo_loader.py
@@ -177,7 +177,11 @@ class StandardTomoLoader(DataSetSource):
         # Fill in numpy array with "before" and "after" padded areas needed for block
         if start_idx[self._slicing_dim] < 0:
             extrapolate_before(
-                self._data, block_data, self._padding[0], self._slicing_dim
+                self._data,
+                block_data,
+                self._padding[0],
+                self._slicing_dim,
+                offset=self._data_offset[self._slicing_dim],
             )
             before_extended_read = False
 

--- a/tests/data/test_padding.py
+++ b/tests/data/test_padding.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from httomo.data.padding import extrapolate_after, extrapolate_before
+from httomo.preview import PreviewConfig, PreviewDimConfig
 
 
 @pytest.mark.parametrize(
@@ -36,6 +37,84 @@ def test_extrapolate_before(slicing_dim: int):
     )
 
     extrapolate_before(global_data, block_data, BEFORE_PADDING, slicing_dim)
+    np.testing.assert_array_equal(block_data, expected_padded_block)
+
+
+@pytest.mark.parametrize(
+    "slicing_dim",
+    [0, 1],
+    ids=["projection-padding", "sinogram-padding"],
+)
+def test_extrapolate_before_previewed(slicing_dim: int):
+    GLOBAL_SHAPE = (180, 128, 160)
+    UNPADDED_BLOCK_LENGTH = 5
+    BEFORE_PADDING = 3
+    # Note the cropping in the `detector_y` dimension that shifts the start of the data from
+    # index 0 to index 10
+    PREVIEW_CONFIG = PreviewConfig(
+        angles=PreviewDimConfig(start=0, stop=180),
+        detector_y=PreviewDimConfig(start=10, stop=128),
+        detector_x=PreviewDimConfig(start=0, stop=160),
+    )
+    DIMS = [0, 1, 2]
+    non_slicing_dims = tuple(set(DIMS) - set([slicing_dim]))
+    global_data = np.arange(np.prod(GLOBAL_SHAPE), dtype=np.float32).reshape(
+        GLOBAL_SHAPE
+    )
+
+    # Due to the cropping being in the `detector_y` dimension:
+    # - if padding is in the `angles` dim, then the cropping affects the block shape's
+    # non-slicing dims
+    # - if padding is in the `detector_y` dim, then the cropping doesn't affect the block
+    # shape's non-slicing dims
+    padded_block_shape: List[int] = list(GLOBAL_SHAPE)
+    padded_block_shape[slicing_dim] = UNPADDED_BLOCK_LENGTH + BEFORE_PADDING
+    if slicing_dim == 0:
+        for dim in non_slicing_dims:
+            padded_block_shape[dim] = (
+                PREVIEW_CONFIG[dim].stop - PREVIEW_CONFIG[dim].start
+            )
+
+    # Setup numpy array containing the expected values after modification by
+    # `extrapolate_before()` (namely, that the "before" padded area has been filled in, and
+    # nothing else in the `expected_padded_block` array has been changed)
+    expected_padded_block = np.zeros(padded_block_shape, dtype=np.float32)
+
+    # If the slicing/padding dim is the `angles` dim, then the slice to repeat for the block's
+    # "before" padded area is the 0th slice in the `angles` dim, with `detector_y` cropped to
+    # start at index 10.
+    #
+    # If the slicing/padding dim is the `detector_y` dim, because the cropping is also in the
+    # `detector_y` dim, the padding needs to applied more carefully. The slice to be repeated
+    # for the "before" padded area needs to be the start of the cropped region along the
+    # `detector_y` dimension (ie, the slice with index 10).
+    slices_read = [slice(None)] * 3
+    slices_read[slicing_dim] = slice(
+        PREVIEW_CONFIG[slicing_dim].start,
+        PREVIEW_CONFIG[slicing_dim].start + 1,
+    )
+
+    if slicing_dim == 0:
+        for dim in non_slicing_dims:
+            slices_read[dim] = slice(
+                PREVIEW_CONFIG[dim].start, PREVIEW_CONFIG[dim].stop
+            )
+
+    slices_write = [slice(None)] * 3
+    slices_write[slicing_dim] = slice(BEFORE_PADDING)
+    expected_padded_block[slices_write[0], slices_write[1], slices_write[2]] = (
+        global_data[slices_read[0], slices_read[1], slices_read[2]]
+    )
+
+    # Block to have its "before" padded area filled in by the extrapolation function
+    block_data = np.zeros(padded_block_shape, dtype=np.float32)
+    extrapolate_before(
+        global_data,
+        block_data,
+        BEFORE_PADDING,
+        slicing_dim,
+        preview_config=PREVIEW_CONFIG,
+    )
     np.testing.assert_array_equal(block_data, expected_padded_block)
 
 

--- a/tests/data/test_padding.py
+++ b/tests/data/test_padding.py
@@ -154,3 +154,83 @@ def test_extrapolate_after(slicing_dim: int):
 
     extrapolate_after(global_data, block_data, AFTER_PADDING, slicing_dim)
     np.testing.assert_array_equal(block_data, expected_padded_block)
+
+
+@pytest.mark.parametrize(
+    "slicing_dim",
+    [0, 1],
+    ids=["projection-padding", "sinogram-padding"],
+)
+def test_extrapolate_after_previewed(slicing_dim: int):
+    GLOBAL_SHAPE = (180, 128, 160)
+    UNPADDED_BLOCK_LENGTH = 5
+    AFTER_PADDING = 3
+    # Note the cropping in the `detector_y` dimension that shifts the end of the data from
+    # index 128 to index 118
+    PREVIEW_CONFIG = PreviewConfig(
+        angles=PreviewDimConfig(start=0, stop=180),
+        detector_y=PreviewDimConfig(start=0, stop=118),
+        detector_x=PreviewDimConfig(start=0, stop=160),
+    )
+    DIMS = [0, 1, 2]
+    non_slicing_dims = tuple(set(DIMS) - set([slicing_dim]))
+    global_data = np.arange(np.prod(GLOBAL_SHAPE), dtype=np.float32).reshape(
+        GLOBAL_SHAPE
+    )
+
+    # Due to the cropping being in the `detector_y` dimension:
+    # - if padding is in the `angles` dim, then the cropping affects the block shape's
+    # non-slicing dims
+    # - if padding is in the `detector_y` dim, then the cropping doesn't affect the block
+    # shape's non-slicing dims
+    padded_block_shape: List[int] = list(GLOBAL_SHAPE)
+    padded_block_shape[slicing_dim] = UNPADDED_BLOCK_LENGTH + AFTER_PADDING
+    if slicing_dim == 0:
+        for dim in non_slicing_dims:
+            padded_block_shape[dim] = (
+                PREVIEW_CONFIG[dim].stop - PREVIEW_CONFIG[dim].start
+            )
+
+    # Setup numpy array containing the expected values after modification by
+    # `extrapolate_after()` (namely, that the "after" padded area has been filled in, and
+    # nothing else in the `expected_padded_block` array has been changed)
+    expected_padded_block = np.zeros(padded_block_shape, dtype=np.float32)
+
+    # If the slicing/padding dim is the `angles` dim, then the the slice to repeat for the
+    # block's "after" padded area is the last slice in the `angles` dim, with `detector_y`
+    # cropped to end at index 117.
+    #
+    # If the slicing/padding dim is the `detector_y` dim, because the cropping is also in the
+    # `detector_y` dim, the padding needs to be applied more carefully. The slice to be
+    # repeated for the "after" padded area needs to be the end of the cropped region along the
+    # `detector_y` dim (ie, the slice with index 117).
+    slices_read = [slice(None)] * 3
+    slices_read[slicing_dim] = slice(
+        PREVIEW_CONFIG[slicing_dim].stop - 1,
+        PREVIEW_CONFIG[slicing_dim].stop,
+    )
+
+    if slicing_dim == 0:
+        for dim in non_slicing_dims:
+            slices_read[dim] = slice(
+                PREVIEW_CONFIG[dim].start, PREVIEW_CONFIG[dim].stop
+            )
+
+    slices_write = [slice(None)] * 3
+    slices_write[slicing_dim] = slice(
+        padded_block_shape[slicing_dim] - AFTER_PADDING, padded_block_shape[slicing_dim]
+    )
+    expected_padded_block[slices_write[0], slices_write[1], slices_write[2]] = (
+        global_data[slices_read[0], slices_read[1], slices_read[2]]
+    )
+
+    # Block to have its "after" padded area filled in by the extrapolation function
+    block_data = np.zeros(padded_block_shape, dtype=np.float32)
+    extrapolate_after(
+        global_data,
+        block_data,
+        AFTER_PADDING,
+        slicing_dim,
+        preview_config=PREVIEW_CONFIG,
+    )
+    np.testing.assert_array_equal(block_data, expected_padded_block)

--- a/tests/data/test_padding.py
+++ b/tests/data/test_padding.py
@@ -1,0 +1,77 @@
+from typing import List
+import numpy as np
+import pytest
+
+from httomo.data.padding import extrapolate_after, extrapolate_before
+
+
+@pytest.mark.parametrize(
+    "slicing_dim",
+    [0, 1],
+    ids=["projection-padding", "sinogram-padding"],
+)
+def test_extrapolate_before(slicing_dim: int):
+    GLOBAL_SHAPE = (180, 128, 160)
+    UNPADDED_BLOCK_LENGTH = 5
+    BEFORE_PADDING = 3
+
+    # Setup the block data to be padded with values from the parent chunk in the global data
+    padded_block_shape: List[int] = list(GLOBAL_SHAPE)
+    padded_block_shape[slicing_dim] = UNPADDED_BLOCK_LENGTH + BEFORE_PADDING
+    global_data = np.arange(np.prod(GLOBAL_SHAPE), dtype=np.float32).reshape(
+        GLOBAL_SHAPE
+    )
+    block_data = np.zeros(padded_block_shape, dtype=np.float32)
+
+    # Setup numpy array containing the expected values after modification by
+    # `extrapolate_before()` (namely, that the "before" padded area has been filled in, and
+    # nothing else in the `expected_padded_block` array has been changed)
+    expected_padded_block = np.zeros(padded_block_shape, dtype=np.float32)
+    slices_read = [slice(None)] * 3
+    slices_read[slicing_dim] = slice(1)
+    slices_write = [slice(None)] * 3
+    slices_write[slicing_dim] = slice(BEFORE_PADDING)
+    expected_padded_block[slices_write[0], slices_write[1], slices_write[2]] = (
+        global_data[slices_read[0], slices_read[1], slices_read[2]]
+    )
+
+    extrapolate_before(global_data, block_data, BEFORE_PADDING, slicing_dim)
+    np.testing.assert_array_equal(block_data, expected_padded_block)
+
+
+@pytest.mark.parametrize(
+    "slicing_dim",
+    [0, 1],
+    ids=["projection-padding", "sinogram-padding"],
+)
+def test_extrapolate_after(slicing_dim: int):
+    GLOBAL_SHAPE = (180, 128, 160)
+    UNPADDED_BLOCK_LENGTH = 5
+    AFTER_PADDING = 3
+
+    # Setup the block data to be padded with values from the parent chunk in the global data
+    padded_block_shape: List[int] = list(GLOBAL_SHAPE)
+    padded_block_shape[slicing_dim] = UNPADDED_BLOCK_LENGTH + AFTER_PADDING
+    global_data = np.arange(np.prod(GLOBAL_SHAPE), dtype=np.float32).reshape(
+        GLOBAL_SHAPE
+    )
+    block_data = np.zeros(padded_block_shape, dtype=np.float32)
+
+    # Setup numpy array containing the expected values after modification by
+    # `extrapolate_after()` (namely, that the "after" padded area has been filled in, and
+    # nothing else in the `expected_padded_block` array has been changed)
+    expected_padded_block = np.zeros(padded_block_shape, dtype=np.float32)
+    slices_read = [slice(None)] * 3
+    slices_read[slicing_dim] = slice(
+        GLOBAL_SHAPE[slicing_dim] - 1, GLOBAL_SHAPE[slicing_dim]
+    )
+    slices_write = [slice(None)] * 3
+    slices_write[slicing_dim] = slice(
+        padded_block_shape[slicing_dim] - AFTER_PADDING, padded_block_shape[slicing_dim]
+    )
+    expected_padded_block[slices_write[0], slices_write[1], slices_write[2]] = (
+        global_data[slices_read[0], slices_read[1], slices_read[2]]
+    )
+
+    extrapolate_after(global_data, block_data, AFTER_PADDING, slicing_dim)
+    np.testing.assert_array_equal(block_data, expected_padded_block)

--- a/tests/loaders/test_standard_tomo_loader.py
+++ b/tests/loaders/test_standard_tomo_loader.py
@@ -887,3 +887,118 @@ def test_standard_tomo_loader_read_block_padded_lower_boundary_single_proc(
     assert block2.chunk_index == BLOCK2_EXPECTED_CHUNK_INDEX
     assert block2.chunk_index_unpadded == BLOCK2_EXPECTED_CHUNK_INDEX_UNPADDED
     assert block2.data.shape == expected_block_shape
+
+
+def test_standard_tomo_loader_read_block_padded_upper_boundary_single_proc(
+    standard_data_path: str,
+    standard_image_key_path: str,
+):
+    # NOTE: The standard tomo testing data contains darks/flats at the end of the dataset which
+    # requires more logic when getting padded blocks at the upper boundary of the data. This is
+    # why it has been used for testing laoding padded blocks at the upper boundary.
+    IN_FILE_PATH = Path(__file__).parent.parent / "test_data/tomo_standard.nxs"
+    DARKS_FLATS_CONFIG = DarksFlatsFileConfig(
+        file=IN_FILE_PATH,
+        data_path=standard_data_path,
+        image_key_path=standard_image_key_path,
+    )
+    ANGLES_CONFIG = RawAngles(data_path="/entry1/tomo_entry/data/rotation_angle")
+    SLICING_DIM: SlicingDimType = 0
+    COMM = MPI.COMM_WORLD
+    PREVIEW_CONFIG = PreviewConfig(
+        angles=PreviewDimConfig(start=0, stop=180),
+        detector_y=PreviewDimConfig(start=0, stop=128),
+        detector_x=PreviewDimConfig(start=0, stop=160),
+    )
+    PADDING = (2, 3)
+
+    with mock.patch(
+        "httomo.darks_flats.get_darks_flats",
+        return_value=(np.zeros(1), np.zeros(1)),
+    ):
+        loader = StandardTomoLoader(
+            in_file=IN_FILE_PATH,
+            data_path=DARKS_FLATS_CONFIG.data_path,
+            image_key_path=DARKS_FLATS_CONFIG.image_key_path,
+            darks=DARKS_FLATS_CONFIG,
+            flats=DARKS_FLATS_CONFIG,
+            angles=ANGLES_CONFIG,
+            preview_config=PREVIEW_CONFIG,
+            slicing_dim=SLICING_DIM,
+            comm=COMM,
+            padding=PADDING,
+        )
+
+    # Defining values for block-reading
+    BLOCK_LENGTH = 4
+    PROJS_START = 0
+    BLOCK1_START = loader.global_shape[SLICING_DIM] - 2 * BLOCK_LENGTH
+    BLOCK2_START = BLOCK1_START + BLOCK_LENGTH
+    expected_block_shape = (
+        BLOCK_LENGTH + PADDING[0] + PADDING[1],
+        PREVIEW_CONFIG.detector_y.stop - PREVIEW_CONFIG.detector_y.start,
+        PREVIEW_CONFIG.detector_x.stop - PREVIEW_CONFIG.detector_x.start,
+    )
+
+    # Index of block relative to the chunk it belongs to, including padding
+    BLOCK1_EXPECTED_CHUNK_INDEX = (BLOCK1_START - PADDING[0], 0, 0)
+    BLOCK1_EXPECTED_CHUNK_INDEX_UNPADDED = (BLOCK1_START, 0, 0)
+    BLOCK2_EXPECTED_CHUNK_INDEX = (BLOCK2_START - PADDING[0], 0, 0)
+    BLOCK2_EXPECTED_CHUNK_INDEX_UNPADDED = (BLOCK2_START, 0, 0)
+
+    # Index of block relative to the global data it belongs to (ie, includes chunk shift - for
+    # single proc, this is the same as the expected chunk index), including padding
+    BLOCK1_EXPECTED_GLOBAL_INDEX = (BLOCK1_START - PADDING[0], 0, 0)
+    BLOCK1_EXPECTED_GLOBAL_INDEX_UNPADDED = (BLOCK1_START, 0, 0)
+    BLOCK2_EXPECTED_GLOBAL_INDEX = (BLOCK2_START - PADDING[0], 0, 0)
+    BLOCK2_EXPECTED_GLOBAL_INDEX_UNPADDED = (BLOCK2_START, 0, 0)
+
+    # Block next to the upper boundary
+    block1 = loader.read_block(BLOCK1_START, BLOCK_LENGTH)
+    # Block on the upper boundary
+    block2 = loader.read_block(BLOCK2_START, BLOCK_LENGTH)
+
+    with h5py.File(IN_FILE_PATH, "r") as f:
+        dataset: h5py.Dataset = f[standard_data_path]
+        expected_block1_data: np.ndarray = dataset[
+            PROJS_START
+            + BLOCK1_START
+            - PADDING[0] : PROJS_START
+            + BLOCK1_START
+            + BLOCK_LENGTH
+            + PADDING[1],
+            PREVIEW_CONFIG.detector_y.start : PREVIEW_CONFIG.detector_y.stop,
+            PREVIEW_CONFIG.detector_x.start : PREVIEW_CONFIG.detector_x.stop,
+        ]
+
+        expected_block2_data: np.ndarray = dataset[
+            PROJS_START
+            + BLOCK2_START
+            - PADDING[0] : PROJS_START
+            + BLOCK2_START
+            + BLOCK_LENGTH,
+            PREVIEW_CONFIG.detector_y.start : PREVIEW_CONFIG.detector_y.stop,
+            PREVIEW_CONFIG.detector_x.start : PREVIEW_CONFIG.detector_x.stop,
+        ]
+
+    # Pad the upper boundary of `block2` using edge mode, because `block2` is on the upper
+    # boundary of the chunk it belongs to
+    expected_block2_data = np.pad(
+        expected_block2_data,
+        pad_width=((0, PADDING[1]), (0, 0), (0, 0)),
+        mode="edge",
+    )
+
+    np.testing.assert_array_equal(block1.data, expected_block1_data)
+    assert block1.global_index == BLOCK1_EXPECTED_GLOBAL_INDEX
+    assert block1.global_index_unpadded == BLOCK1_EXPECTED_GLOBAL_INDEX_UNPADDED
+    assert block1.chunk_index == BLOCK1_EXPECTED_CHUNK_INDEX
+    assert block1.chunk_index_unpadded == BLOCK1_EXPECTED_CHUNK_INDEX_UNPADDED
+    assert block1.data.shape == expected_block_shape
+
+    np.testing.assert_array_equal(block2.data, expected_block2_data)
+    assert block2.global_index == BLOCK2_EXPECTED_GLOBAL_INDEX
+    assert block2.global_index_unpadded == BLOCK2_EXPECTED_GLOBAL_INDEX_UNPADDED
+    assert block2.chunk_index == BLOCK2_EXPECTED_CHUNK_INDEX
+    assert block2.chunk_index_unpadded == BLOCK2_EXPECTED_CHUNK_INDEX_UNPADDED
+    assert block2.data.shape == expected_block_shape

--- a/tests/loaders/test_standard_tomo_loader.py
+++ b/tests/loaders/test_standard_tomo_loader.py
@@ -775,3 +775,115 @@ def test_standard_tomo_loader_properties_reflect_nonzero_padding(
     assert loader.chunk_shape == EXPECTED_CHUNK_SHAPE
     assert loader.global_shape == EXPECTED_GLOBAL_SHAPE
     assert loader.global_index == EXPECTED_GLOBAL_INDEX
+
+
+def test_standard_tomo_loader_read_block_padded_lower_boundary_single_proc(
+    standard_data_path: str,
+    standard_image_key_path: str,
+):
+    IN_FILE_PATH = Path(__file__).parent.parent / "test_data/tomo_standard.nxs"
+    DARKS_FLATS_CONFIG = DarksFlatsFileConfig(
+        file=IN_FILE_PATH,
+        data_path=standard_data_path,
+        image_key_path=standard_image_key_path,
+    )
+    ANGLES_CONFIG = RawAngles(data_path="/entry1/tomo_entry/data/rotation_angle")
+    SLICING_DIM: SlicingDimType = 0
+    COMM = MPI.COMM_WORLD
+    PREVIEW_CONFIG = PreviewConfig(
+        angles=PreviewDimConfig(start=0, stop=180),
+        detector_y=PreviewDimConfig(start=0, stop=128),
+        detector_x=PreviewDimConfig(start=0, stop=160),
+    )
+    PADDING = (2, 3)
+
+    with mock.patch(
+        "httomo.darks_flats.get_darks_flats",
+        return_value=(np.zeros(1), np.zeros(1)),
+    ):
+        loader = StandardTomoLoader(
+            in_file=IN_FILE_PATH,
+            data_path=DARKS_FLATS_CONFIG.data_path,
+            image_key_path=DARKS_FLATS_CONFIG.image_key_path,
+            darks=DARKS_FLATS_CONFIG,
+            flats=DARKS_FLATS_CONFIG,
+            angles=ANGLES_CONFIG,
+            preview_config=PREVIEW_CONFIG,
+            slicing_dim=SLICING_DIM,
+            comm=COMM,
+            padding=PADDING,
+        )
+
+    # Defining values for block-reading
+    BLOCK_LENGTH = 4
+    PROJS_START = 0
+    BLOCK1_START = 0
+    BLOCK2_START = BLOCK1_START + BLOCK_LENGTH
+    expected_block_shape = (
+        BLOCK_LENGTH + PADDING[0] + PADDING[1],
+        PREVIEW_CONFIG.detector_y.stop - PREVIEW_CONFIG.detector_y.start,
+        PREVIEW_CONFIG.detector_x.stop - PREVIEW_CONFIG.detector_x.start,
+    )
+
+    # Index of block relative to the chunk it belongs to, including padding
+    BLOCK1_EXPECTED_CHUNK_INDEX = (BLOCK1_START - PADDING[0], 0, 0)
+    BLOCK1_EXPECTED_CHUNK_INDEX_UNPADDED = (BLOCK1_START, 0, 0)
+    BLOCK2_EXPECTED_CHUNK_INDEX = (BLOCK2_START - PADDING[0], 0, 0)
+    BLOCK2_EXPECTED_CHUNK_INDEX_UNPADDED = (BLOCK2_START, 0, 0)
+
+    # Index of block relative to the global data it belongs to (ie, includes chunk shift - for
+    # single proc, this is the same as the expected chunk index), including padding
+    BLOCK1_EXPECTED_GLOBAL_INDEX = (BLOCK1_START - PADDING[0], 0, 0)
+    BLOCK1_EXPECTED_GLOBAL_INDEX_UNPADDED = (BLOCK1_START, 0, 0)
+    BLOCK2_EXPECTED_GLOBAL_INDEX = (BLOCK2_START - PADDING[0], 0, 0)
+    BLOCK2_EXPECTED_GLOBAL_INDEX_UNPADDED = (BLOCK2_START, 0, 0)
+
+    # Block on the lower boundary
+    block1 = loader.read_block(BLOCK1_START, BLOCK_LENGTH)
+    # Next block along
+    block2 = loader.read_block(BLOCK2_START, BLOCK_LENGTH)
+
+    with h5py.File(IN_FILE_PATH, "r") as f:
+        dataset: h5py.Dataset = f[standard_data_path]
+        expected_block1_data: np.ndarray = dataset[
+            PROJS_START
+            + BLOCK1_START : PROJS_START
+            + BLOCK1_START
+            + BLOCK_LENGTH
+            + PADDING[1],
+            PREVIEW_CONFIG.detector_y.start : PREVIEW_CONFIG.detector_y.stop,
+            PREVIEW_CONFIG.detector_x.start : PREVIEW_CONFIG.detector_x.stop,
+        ]
+
+        expected_block2_data: np.ndarray = dataset[
+            PROJS_START
+            + BLOCK2_START
+            - PADDING[0] : PROJS_START
+            + BLOCK2_START
+            + BLOCK_LENGTH
+            + PADDING[1],
+            PREVIEW_CONFIG.detector_y.start : PREVIEW_CONFIG.detector_y.stop,
+            PREVIEW_CONFIG.detector_x.start : PREVIEW_CONFIG.detector_x.stop,
+        ]
+
+    # Pad the lower boundary of `block1` using edge mode, because `block1` is on the lower
+    # boundary of the chunk it belongs to
+    expected_block1_data = np.pad(
+        expected_block1_data,
+        pad_width=((PADDING[0], 0), (0, 0), (0, 0)),
+        mode="edge",
+    )
+
+    np.testing.assert_array_equal(block1.data, expected_block1_data)
+    assert block1.global_index == BLOCK1_EXPECTED_GLOBAL_INDEX
+    assert block1.global_index_unpadded == BLOCK1_EXPECTED_GLOBAL_INDEX_UNPADDED
+    assert block1.chunk_index == BLOCK1_EXPECTED_CHUNK_INDEX
+    assert block1.chunk_index_unpadded == BLOCK1_EXPECTED_CHUNK_INDEX_UNPADDED
+    assert block1.data.shape == expected_block_shape
+
+    np.testing.assert_array_equal(block2.data, expected_block2_data)
+    assert block2.global_index == BLOCK2_EXPECTED_GLOBAL_INDEX
+    assert block2.global_index_unpadded == BLOCK2_EXPECTED_GLOBAL_INDEX_UNPADDED
+    assert block2.chunk_index == BLOCK2_EXPECTED_CHUNK_INDEX
+    assert block2.chunk_index_unpadded == BLOCK2_EXPECTED_CHUNK_INDEX_UNPADDED
+    assert block2.data.shape == expected_block_shape

--- a/tests/loaders/test_standard_tomo_loader.py
+++ b/tests/loaders/test_standard_tomo_loader.py
@@ -777,7 +777,30 @@ def test_standard_tomo_loader_properties_reflect_nonzero_padding(
     assert loader.global_index == EXPECTED_GLOBAL_INDEX
 
 
-def test_standard_tomo_loader_read_block_padded_outer_chunk_boundary_lower_boundary_single_proc():
+@pytest.mark.parametrize(
+    "preview_config",
+    [
+        PreviewConfig(
+            angles=PreviewDimConfig(start=0, stop=3201),
+            detector_y=PreviewDimConfig(start=0, stop=22),
+            detector_x=PreviewDimConfig(start=0, stop=26),
+        ),
+        PreviewConfig(
+            angles=PreviewDimConfig(start=0, stop=3201),
+            detector_y=PreviewDimConfig(start=5, stop=17),
+            detector_x=PreviewDimConfig(start=0, stop=26),
+        ),
+        PreviewConfig(
+            angles=PreviewDimConfig(start=0, stop=3201),
+            detector_y=PreviewDimConfig(start=0, stop=22),
+            detector_x=PreviewDimConfig(start=5, stop=21),
+        ),
+    ],
+    ids=["no_cropping", "crop_det_y_both_ends", "crop_det_x_both_ends"],
+)
+def test_standard_tomo_loader_read_block_padded_outer_chunk_boundary_lower_boundary_single_proc(
+    preview_config: PreviewConfig,
+):
     # NOTE: The phrase "outer chunk boundary" refers to either of the two boundaries of a chunk
     # that lie on the boundary of the global data in the hdf5 file. For this test, the "outer
     # chunk boundary" is the boundary of the chunk on the lower boundary of the global data.
@@ -796,11 +819,6 @@ def test_standard_tomo_loader_read_block_padded_outer_chunk_boundary_lower_bound
     ANGLES_CONFIG = RawAngles(data_path="/entry/imaging_sum/gts_theta_value")
     SLICING_DIM: SlicingDimType = 0
     COMM = MPI.COMM_WORLD
-    PREVIEW_CONFIG = PreviewConfig(
-        angles=PreviewDimConfig(start=0, stop=3201),
-        detector_y=PreviewDimConfig(start=0, stop=22),
-        detector_x=PreviewDimConfig(start=0, stop=26),
-    )
     PADDING = (2, 3)
 
     with mock.patch(
@@ -814,7 +832,7 @@ def test_standard_tomo_loader_read_block_padded_outer_chunk_boundary_lower_bound
             darks=DARKS_FLATS_CONFIG,
             flats=DARKS_FLATS_CONFIG,
             angles=ANGLES_CONFIG,
-            preview_config=PREVIEW_CONFIG,
+            preview_config=preview_config,
             slicing_dim=SLICING_DIM,
             comm=COMM,
             padding=PADDING,
@@ -826,8 +844,8 @@ def test_standard_tomo_loader_read_block_padded_outer_chunk_boundary_lower_bound
     BLOCK_START = 0  # block is on the lower boundary of the chunk
     expected_block_shape = (
         BLOCK_LENGTH + PADDING[0] + PADDING[1],
-        PREVIEW_CONFIG.detector_y.stop - PREVIEW_CONFIG.detector_y.start,
-        PREVIEW_CONFIG.detector_x.stop - PREVIEW_CONFIG.detector_x.start,
+        preview_config.detector_y.stop - preview_config.detector_y.start,
+        preview_config.detector_x.stop - preview_config.detector_x.start,
     )
 
     # Index of block relative to the chunk it belongs to, including padding
@@ -850,8 +868,8 @@ def test_standard_tomo_loader_read_block_padded_outer_chunk_boundary_lower_bound
             + BLOCK_START
             + BLOCK_LENGTH
             + PADDING[1],
-            PREVIEW_CONFIG.detector_y.start : PREVIEW_CONFIG.detector_y.stop,
-            PREVIEW_CONFIG.detector_x.start : PREVIEW_CONFIG.detector_x.stop,
+            preview_config.detector_y.start : preview_config.detector_y.stop,
+            preview_config.detector_x.start : preview_config.detector_x.stop,
         ]
 
     # Pad the lower boundary of `block` using edge mode, because `block` is on the lower


### PR DESCRIPTION
Fixes #414

Main changes:
- `_extrapolate_*()` methods in data store reader have been extracted into a separate `padding.py` module for reuse by the loader
- enable `StandardTomoLoader` to load padded blocks (with or without previewing applied to the original data) 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation (no documentation changes necessary)
