### PR TITLE
Ensure no Python objects pointed to CuPy array before cleaning its memory pool 

### DIFF
--- a/httomo/methods_database/packages/external/httomolibgpu/supporting_funcs/recon/algorithm.py
+++ b/httomo/methods_database/packages/external/httomolibgpu/supporting_funcs/recon/algorithm.py
@@ -139,24 +139,14 @@ def _calc_memory_bytes_FBP(
     # BUT: this swapaxis happens after the cudaArray inputs and the input swapaxis arrays are dropped,
     #      so it does not add to the memory overall
 
-    # NOTE
-    # Although the assumption that the memory will be cleared after filtration step (the fft plans)
-    # does hold for some WSs, on the cluster it results in OOM error in the IFFT step.
-    # It is not very clear why it is the case so far, therefore the workaround is to account for all memory required
-    # for the FBP step (filtering part + ASTRA backprojection). This is not ideal as it uses a lot of memory
-    # and therefore the blocks will be smaller making I/O suboptimal.
-
-    # The commented code bellow is how the memory should be estimated in principle
-    # if projection_mem_size > filtersync_size:
-    #     tot_memory_bytes = int(filtersync_output_slice_size + projection_mem_size)
-    # else:
-    #     tot_memory_bytes = int(filtersync_output_slice_size + filtersync_size + recon_output_size)
+    if projection_mem_size > filtersync_size:
+        tot_memory_bytes = int(filtersync_output_slice_size + projection_mem_size)
+    else:
+        # here we do not add recon_output_size as we assume that at least one fft plan will be released before the
+        # the backprojection step which is SMALLER than the current estimation.
+        tot_memory_bytes = int(filtersync_output_slice_size + filtersync_size)
 
     # this account for the memory used for filtration AND backprojection.
-    tot_memory_bytes = int(
-        filtersync_output_slice_size + filtersync_size + projection_mem_size
-    )
-
     return (tot_memory_bytes, fixed_amount)
 
 

--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -193,6 +193,12 @@ class DataSetBlock(BaseBlock, BlockIndexing):
         self._global_shape = make_3d_shape_from_shape(global_shape)
         self._chunk_shape = make_3d_shape_from_shape(chunk_shape)
 
+    @data.deleter
+    def data(self):
+        del self._data
+        del self._global_shape
+        del self._chunk_shape
+
     @property
     def is_padded(self) -> bool:
         return self._padding != (0, 0)

--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -149,7 +149,12 @@ class TaskRunner:
                     block.global_index,
                     (end_sink - start_sink) * 1e-9,
                 )
+
+            # remove the reference pointing to the CuPy array before
+            # calling the clean-up rountine
+            del block.data
             gpumem_cleanup()
+
             start_source = time.perf_counter_ns()
 
         self._log_pipeline(


### PR DESCRIPTION
This PR removes the reference to CuPy array inside `DataSetBlock` before cleaning up by the CuPy memory pool. This ensures no Python object refers to the underlying CuPy memory pointer, so the CuPy memory pool knows the memory pointer is not referenced by some Python objects, and the memory pool can be properly cleaned up.

A simple deleter of `data` attribute in `DataSetBlock` is implemented to help the deletion of the CuPy array. 

Together with [this fix in `httomolibgpu`](https://github.com/DiamondLightSource/httomolibgpu/pull/145), it solves the GPU memory leak issue.