### PR TITLE
A feature for Sweep to insert save_to_images methods automatically 

### DIFF
--- a/docs/source/howto/httomo_features/parameter_sweeping.rst
+++ b/docs/source/howto/httomo_features/parameter_sweeping.rst
@@ -77,6 +77,8 @@ pipeline to sweep over the :code:`size` parameter of a median filter:
 .. literalinclude:: ../../../../tests/samples/pipeline_template_examples/testing/sweep_manual.yaml
   :language: yaml
 
+.. note:: There is no need to add image saving method after the `sweep` method. The result of the `sweep` method will be saved into images automatically. 
+
 How big should the input data be?
 =================================
 

--- a/docs/source/pipelines/yaml.rst
+++ b/docs/source/pipelines/yaml.rst
@@ -58,9 +58,16 @@ Parameter Sweeps templates
 These templates demonstrate how to perform a sweep across multiple values of a
 single parameter (see :ref:`parameter_sweeping` for more details).
 
-.. dropdown:: Parameter sweep over 10 CoR values (`center` param) in recon
-   method, and saving the result as tiffs
+.. dropdown:: Parameter sweep over 6 CoR values (`center` param) in recon
+   method, and saving the result as tiffs. Note that there is need to add image saving plugin in this case. It is also preferable to keep `preview` small. 
 
    .. literalinclude:: ../../../tests/samples/pipeline_template_examples/parameter-sweep-cor.yaml
        :language: yaml
-       :emphasize-lines: 9-11,37-40
+       :emphasize-lines: 30-33
+       
+.. dropdown:: Parameter sweep over 50 (`alpha` param) values of Paganin filter
+   method, and saving the result as tiffs for both Paganin filter and the reconstruction module.
+          
+   .. literalinclude:: ../../../tests/samples/pipeline_template_examples/parameter-sweep-paganin.yaml
+       :language: yaml
+       :emphasize-lines: 25-28       

--- a/httomo/method_wrappers/generic.py
+++ b/httomo/method_wrappers/generic.py
@@ -105,8 +105,8 @@ class GenericMethodWrapper(MethodWrapper):
         self._config_params = kwargs
         # check if a tuple present in parameters to make the method a sweep method
         self._sweep = False
-        for _, value in enumerate(self._config_params):
-            if type(self._config_params[value]) is tuple:
+        for value in self._config_params.values():
+            if type(value) is tuple:
                 self._sweep = True
         self._output_mapping = output_mapping
         self._check_config_params()

--- a/httomo/method_wrappers/generic.py
+++ b/httomo/method_wrappers/generic.py
@@ -103,6 +103,11 @@ class GenericMethodWrapper(MethodWrapper):
 
         # check if the given kwargs are actually supported by the method
         self._config_params = kwargs
+        # check if a tuple present in parameters to make the method a sweep method
+        self._sweep = False
+        for _, value in enumerate(self._config_params):
+            if type(self._config_params[value]) is tuple:
+                self._sweep = True
         self._output_mapping = output_mapping
         self._check_config_params()
 
@@ -221,6 +226,10 @@ class GenericMethodWrapper(MethodWrapper):
     @property
     def padding(self) -> bool:
         return self._padding
+
+    @property
+    def sweep(self) -> bool:
+        return self._sweep
 
     def _build_kwargs(
         self,

--- a/httomo/runner/method_wrapper.py
+++ b/httomo/runner/method_wrapper.py
@@ -129,7 +129,12 @@ class MethodWrapper(Protocol):
 
     @property
     def padding(self) -> bool:
-        """Deterime if the method needs padding"""
+        """Determine if the method needs padding"""
+        ...  # pragma: nocover
+
+    @property
+    def sweep(self) -> bool:
+        """Determine if the method performs sweep"""
         ...  # pragma: nocover
 
     # Methods

--- a/httomo/transform_layer.py
+++ b/httomo/transform_layer.py
@@ -65,7 +65,7 @@ class TransformLayer:
                 "data_reducer",
                 comm=self._comm,
                 save_result=False,
-                task_id=f"task_{0}",
+                task_id=f"reducer_{0}",
             ),
         )
         for m in pipeline:
@@ -89,7 +89,7 @@ class TransformLayer:
                         "save_to_images",
                         comm=self._comm,
                         save_result=False,
-                        task_id=f"task_{0}",
+                        task_id=f"saveimage_sweep_{m.task_id}",
                         subfolder_name="images_sweep_" + str(m.method_name),
                         axis=1,
                         perc_range_min=5,

--- a/httomo/transform_layer.py
+++ b/httomo/transform_layer.py
@@ -65,7 +65,7 @@ class TransformLayer:
                 "data_reducer",
                 comm=self._comm,
                 save_result=False,
-                task_id=f"reducer_{0}",
+                task_id="reducer_0",
             ),
         )
         for m in pipeline:

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -229,6 +229,24 @@ def check_no_required_parameter_values(conf: PipelineConfig) -> bool:
     return True
 
 
+def check_no_imagesaver_after_sweep_method(conf: PipelineConfig) -> bool:
+    """check that there shouldn't be image saver present right after the sweep method"""
+    # required_values = {
+    #     method["method"]: param
+    #     for method in conf
+    #     for param, param_value in method["parameters"].items()
+    #     if param_value == "REQUIRED"
+    # }
+    # for method, param in required_values.items():
+    #     _print_with_colour(
+    #         f"A value is needed for the parameter '{param}' in the '{method}' method."
+    #         " Please specify a value instead of 'REQUIRED'."
+    #         " Refer to the method docstring for more information."
+    #     )
+    #     return False
+    return True
+
+
 def check_no_duplicated_keys(f: Path) -> bool:
     """there should be no duplicate keys in yaml file
     Parameters

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -237,8 +237,8 @@ def check_no_imagesaver_after_sweep_method(f: Path) -> bool:
     pipeline = yaml_loader(f, loader=loader)
 
     method_is_sweep = False
-    for _, m in enumerate(pipeline):
-        for _, value in m["parameters"].items():
+    for m in pipeline:
+        for value in m["parameters"].values():
             if type(value) is tuple:
                 method_is_sweep = True
                 sweep_method_name = m["method"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,9 +292,16 @@ def yaml_gpu_pipeline1():
 def yaml_gpu_pipeline360_2():
     return "tests/samples/pipeline_template_examples/pipeline_360deg_gpu2.yaml"
 
+
 @pytest.fixture
 def yaml_gpu_pipeline_sweep_cor():
     return "tests/samples/pipeline_template_examples/parameter-sweep-cor.yaml"
+
+
+@pytest.fixture
+def yaml_gpu_pipeline_sweep_paganin():
+    return "tests/samples/pipeline_template_examples/parameter-sweep-paganin.yaml"
+
 
 @pytest.fixture(scope="session")
 def distortion_correction_path(test_data_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,6 +292,9 @@ def yaml_gpu_pipeline1():
 def yaml_gpu_pipeline360_2():
     return "tests/samples/pipeline_template_examples/pipeline_360deg_gpu2.yaml"
 
+@pytest.fixture
+def yaml_gpu_pipeline_sweep_cor():
+    return "tests/samples/pipeline_template_examples/parameter-sweep-cor.yaml"
 
 @pytest.fixture(scope="session")
 def distortion_correction_path(test_data_path):

--- a/tests/samples/pipeline_template_examples/parameter-sweep-cor.yaml
+++ b/tests/samples/pipeline_template_examples/parameter-sweep-cor.yaml
@@ -7,15 +7,15 @@
       data_path: /entry1/tomo_entry/data/rotation_angle
     preview:
       detector_y:
-        start: 100
-        stop: 107
+        start: 60
+        stop: 67
 - method: normalize
   module_path: httomolibgpu.prep.normalize
   parameters:
     cutoff: 10.0
-    minus_log: true
+    minus_log: false
     nonnegativity: false
-    remove_nans: false
+    remove_nans: true
 - method: paganin_filter_tomopy
   module_path: httomolibgpu.prep.phase
   parameters:
@@ -23,22 +23,15 @@
     dist: 50.0
     energy: 53.0
     alpha: 0.001
-- method: remove_all_stripe
-  module_path: httomolibgpu.prep.stripe
-  parameters:
-    snr: 3.0
-    la_size: 61
-    sm_size: 21
-    dim: 1
 - method: FBP
   module_path: httomolibgpu.recon.algorithm
   save_result: False
   parameters:
     center: !SweepRange
-      start: 1000
-      stop: 1010
-      step: 1
-    filter_freq_cutoff: 0.6
+      start: 60
+      stop: 120
+      step: 10
+    filter_freq_cutoff: 1.1
     recon_size: null
     recon_mask_radius: null
 - method: save_to_images

--- a/tests/samples/pipeline_template_examples/parameter-sweep-paganin.yaml
+++ b/tests/samples/pipeline_template_examples/parameter-sweep-paganin.yaml
@@ -19,18 +19,17 @@
 - method: paganin_filter_tomopy
   module_path: httomolibgpu.prep.phase
   parameters:
-    pixel_size: 0.0001
+    pixel_size: 0.0004
     dist: 50.0
     energy: 53.0
-    alpha: 0.001
+    alpha: !SweepRange
+      start: 0.001
+      stop: 0.5
+      step: 0.01 
 - method: FBP
   module_path: httomolibgpu.recon.algorithm
-  save_result: False
   parameters:
-    center: !SweepRange
-      start: 60
-      stop: 120
-      step: 10
+    center: 80
     filter_freq_cutoff: 1.1
     recon_size: null
     recon_mask_radius: null

--- a/tests/samples/pipeline_template_examples/testing/imagesave_after_sweep.yaml
+++ b/tests/samples/pipeline_template_examples/testing/imagesave_after_sweep.yaml
@@ -1,0 +1,33 @@
+- method: standard_tomo
+  module_path: httomo.data.hdf.loaders
+  parameters:
+    data_path: entry1/tomo_entry/data/data
+    image_key_path: entry1/tomo_entry/instrument/detector/image_key
+    rotation_angles:
+      data_path: /entry1/tomo_entry/data/rotation_angle
+    preview:
+      detector_y:
+        start: 10
+        stop: 17
+- method: normalize
+  module_path: tomopy.prep.normalize
+  parameters:
+    cutoff: 10.0
+    averaging: mean
+- method: median_filter
+  module_path: tomopy.misc.corr
+  parameters:
+    size: !Sweep
+      - 3
+      - 5
+    axis: 0
+- method: save_to_images
+  module_path: httomolib.misc.images
+  parameters:
+    subfolder_name: images
+    axis: auto
+    file_format: tif
+    bits: 8
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    jpeg_quality: 95    

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -703,7 +703,6 @@ def test_run_pipeline_360deg_gpu2(
     assert "Global mean 0.000889" in verbose_log_contents
 
 
-
 @pytest.mark.cupy
 def test_run_gpu_pipeline_sweep_cor(
     get_files: Callable, cmd, standard_data, yaml_gpu_pipeline_sweep_cor, output_folder
@@ -730,3 +729,36 @@ def test_run_gpu_pipeline_sweep_cor(
     assert "Data shape is (180, 7, 160) of type uint16" in verbose_log_contents
     assert "Total number of values across all processes: 6" in verbose_log_contents
     assert "Values executed in this process: 6" in verbose_log_contents
+
+
+@pytest.mark.cupy
+def test_run_gpu_pipeline_sweep_paganin(
+    get_files: Callable,
+    cmd,
+    standard_data,
+    yaml_gpu_pipeline_sweep_paganin,
+    output_folder,
+):
+    cmd.pop(4)  #: don't save all
+    cmd.insert(6, standard_data)
+    cmd.insert(7, yaml_gpu_pipeline_sweep_paganin)
+    cmd.insert(8, output_folder)
+    subprocess.check_output(cmd)
+
+    # recurse through output_dir and check that all files are there
+    files = get_files("output_dir/")
+    assert len(files) == 104
+
+    #: check the generated h5 files
+    h5_files = list(filter(lambda x: ".h5" in x, files))
+    assert len(h5_files) == 1
+
+    log_files = list(filter(lambda x: ".log" in x, files))
+    assert len(log_files) == 2
+    verbose_log_file = list(filter(lambda x: "debug.log" in x, files))
+    verbose_log_contents = _get_log_contents(verbose_log_file[0])
+
+    assert "Data shape is (180, 7, 160) of type uint16" in verbose_log_contents
+    assert "Total number of values across all processes: 50" in verbose_log_contents
+    assert "Values executed in this process: 50" in verbose_log_contents
+    assert "Parameter name: alpha" in verbose_log_contents

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -701,3 +701,32 @@ def test_run_pipeline_360deg_gpu2(
     assert "Global min -0.002859" in verbose_log_contents
     assert "Global max 0.00561" in verbose_log_contents
     assert "Global mean 0.000889" in verbose_log_contents
+
+
+
+@pytest.mark.cupy
+def test_run_gpu_pipeline_sweep_cor(
+    get_files: Callable, cmd, standard_data, yaml_gpu_pipeline_sweep_cor, output_folder
+):
+    cmd.pop(4)  #: don't save all
+    cmd.insert(6, standard_data)
+    cmd.insert(7, yaml_gpu_pipeline_sweep_cor)
+    cmd.insert(8, output_folder)
+    subprocess.check_output(cmd)
+
+    # recurse through output_dir and check that all files are there
+    files = get_files("output_dir/")
+    assert len(files) == 9
+
+    #: check the generated h5 files
+    h5_files = list(filter(lambda x: ".h5" in x, files))
+    assert len(h5_files) == 0
+
+    log_files = list(filter(lambda x: ".log" in x, files))
+    assert len(log_files) == 2
+    verbose_log_file = list(filter(lambda x: "debug.log" in x, files))
+    verbose_log_contents = _get_log_contents(verbose_log_file[0])
+
+    assert "Data shape is (180, 7, 160) of type uint16" in verbose_log_contents
+    assert "Total number of values across all processes: 6" in verbose_log_contents
+    assert "Values executed in this process: 6" in verbose_log_contents

--- a/tests/test_transform_layer.py
+++ b/tests/test_transform_layer.py
@@ -139,7 +139,7 @@ def test_insert_data_reducer(mocker: MockerFixture, tmp_path: Path):
 
     assert len(pipeline) == 3
     assert pipeline[0].method_name == "data_reducer"
-    assert pipeline[0].task_id == "task_0"
+    assert pipeline[0].task_id == "reducer_0"
 
 
 def test_insert_image_save_after_sweep(mocker: MockerFixture, tmp_path: Path):
@@ -181,7 +181,7 @@ def test_insert_image_save_after_sweep(mocker: MockerFixture, tmp_path: Path):
 
     assert len(pipeline) == 4
     assert pipeline[3].method_name == "save_to_images"
-    assert pipeline[3].task_id == "task_0"
+    assert pipeline[3].task_id == "saveimage_sweep_t3"
     assert (
         pipeline[3].config_params["subfolder_name"]
         == "images_sweep_paganin_filter_tomopy"
@@ -235,13 +235,13 @@ def test_insert_image_save_after_sweep2(mocker: MockerFixture, tmp_path: Path):
 
     assert len(pipeline) == 6
     assert pipeline[3].method_name == "save_to_images"
-    assert pipeline[3].task_id == "task_0"
+    assert pipeline[3].task_id == "saveimage_sweep_t3"
     assert (
         pipeline[3].config_params["subfolder_name"]
         == "images_sweep_paganin_filter_tomopy"
     )
     assert pipeline[3].config_params["axis"] == 1
     assert pipeline[5].method_name == "save_to_images"
-    assert pipeline[5].task_id == "task_0"
+    assert pipeline[5].task_id == "saveimage_sweep_t4"
     assert pipeline[5].config_params["subfolder_name"] == "images_sweep_FBP"
     assert pipeline[5].config_params["axis"] == 1

--- a/tests/test_transform_layer.py
+++ b/tests/test_transform_layer.py
@@ -140,3 +140,108 @@ def test_insert_data_reducer(mocker: MockerFixture, tmp_path: Path):
     assert len(pipeline) == 3
     assert pipeline[0].method_name == "data_reducer"
     assert pipeline[0].task_id == "task_0"
+
+
+def test_insert_image_save_after_sweep(mocker: MockerFixture, tmp_path: Path):
+    comm = MPI.COMM_SELF
+    repo = make_mock_repo(mocker)
+    loader = mocker.create_autospec(
+        LoaderInterface,
+        instance=True,
+    )
+    pipeline = Pipeline(
+        loader=loader,
+        methods=[
+            make_test_method(
+                mocker,
+                method_name="normalize",
+                module_path="httomolibgpu.prep.normalize",
+                save_result=False,
+                task_id="t1",
+            ),
+            make_test_method(
+                mocker,
+                method_name="remove_outlier",
+                module_path="httomolibgpu.misc.corr",
+                save_result=False,
+                task_id="t2",
+            ),
+            make_test_method(
+                mocker,
+                method_name="paganin_filter_tomopy",
+                module_path="httomolibgpu.prep.phase",
+                save_result=False,
+                sweep=True,
+                task_id="t3",
+            ),
+        ],
+    )
+    trans = TransformLayer(comm, repo=repo, save_all=False, out_dir=tmp_path)
+    pipeline = trans.insert_save_images_after_sweep(pipeline)
+
+    assert len(pipeline) == 4
+    assert pipeline[3].method_name == "save_to_images"
+    assert pipeline[3].task_id == "task_0"
+    assert (
+        pipeline[3].config_params["subfolder_name"]
+        == "images_sweep_paganin_filter_tomopy"
+    )
+    assert pipeline[3].config_params["axis"] == 1
+
+
+def test_insert_image_save_after_sweep2(mocker: MockerFixture, tmp_path: Path):
+    comm = MPI.COMM_SELF
+    repo = make_mock_repo(mocker)
+    loader = mocker.create_autospec(
+        LoaderInterface,
+        instance=True,
+    )
+    pipeline = Pipeline(
+        loader=loader,
+        methods=[
+            make_test_method(
+                mocker,
+                method_name="normalize",
+                module_path="httomolibgpu.prep.normalize",
+                save_result=False,
+                task_id="t1",
+            ),
+            make_test_method(
+                mocker,
+                method_name="remove_outlier",
+                module_path="httomolibgpu.misc.corr",
+                save_result=False,
+                task_id="t2",
+            ),
+            make_test_method(
+                mocker,
+                method_name="paganin_filter_tomopy",
+                module_path="httomolibgpu.prep.phase",
+                save_result=False,
+                sweep=True,
+                task_id="t3",
+            ),
+            make_test_method(
+                mocker,
+                method_name="FBP",
+                module_path="httomolibgpu.recon.algorithm",
+                save_result=False,
+                task_id="t4",
+            ),
+        ],
+    )
+    trans = TransformLayer(comm, repo=repo, save_all=False, out_dir=tmp_path)
+    pipeline = trans.insert_save_images_after_sweep(pipeline)
+
+    assert len(pipeline) == 6
+    assert pipeline[3].method_name == "save_to_images"
+    assert pipeline[3].task_id == "task_0"
+    assert (
+        pipeline[3].config_params["subfolder_name"]
+        == "images_sweep_paganin_filter_tomopy"
+    )
+    assert pipeline[3].config_params["axis"] == 1
+    assert pipeline[5].method_name == "save_to_images"
+    assert pipeline[5].task_id == "task_0"
+    assert pipeline[5].config_params["subfolder_name"] == "images_sweep_FBP"
+    assert pipeline[5].config_params["axis"] == 1

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -21,6 +21,7 @@ from httomo.yaml_checker import (
     check_keys,
     sanity_check,
     validate_yaml_config,
+    check_no_imagesaver_after_sweep_method,
 )
 
 
@@ -78,6 +79,11 @@ def test_check_no_required_parameter_values(sample_pipelines: str, load_yaml: Ca
 def test_check_no_duplicated_keys(sample_pipelines: str, load_yaml: Callable):
     required_param_pipeline = sample_pipelines + "testing/duplicated_key.yaml"
     assert not check_no_duplicated_keys(required_param_pipeline)
+
+
+def test_imagesave_after_sweep(sample_pipelines: str, load_yaml: Callable):
+    required_param_pipeline = sample_pipelines + "testing/imagesave_after_sweep.yaml"
+    assert not check_no_imagesaver_after_sweep_method(required_param_pipeline)
 
 
 def test_check_keys(sample_pipelines: str, load_yaml: Callable):

--- a/tests/test_yaml_checker.py
+++ b/tests/test_yaml_checker.py
@@ -3,6 +3,7 @@ Some unit tests for the yaml checker
 """
 
 from typing import Callable
+from pathlib import Path
 
 import pytest
 import yaml
@@ -78,12 +79,12 @@ def test_check_no_required_parameter_values(sample_pipelines: str, load_yaml: Ca
 
 def test_check_no_duplicated_keys(sample_pipelines: str, load_yaml: Callable):
     required_param_pipeline = sample_pipelines + "testing/duplicated_key.yaml"
-    assert not check_no_duplicated_keys(required_param_pipeline)
+    assert not check_no_duplicated_keys(Path(required_param_pipeline))
 
 
 def test_imagesave_after_sweep(sample_pipelines: str, load_yaml: Callable):
     required_param_pipeline = sample_pipelines + "testing/imagesave_after_sweep.yaml"
-    assert not check_no_imagesaver_after_sweep_method(required_param_pipeline)
+    assert not check_no_imagesaver_after_sweep_method(Path(required_param_pipeline))
 
 
 def test_check_keys(sample_pipelines: str, load_yaml: Callable):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -21,6 +21,7 @@ def make_test_method(
     save_result=False,
     task_id: Optional[str] = None,
     padding: bool = False,
+    sweep: bool = False,
     **kwargs,
 ) -> MethodWrapper:
     if task_id is None:
@@ -37,6 +38,7 @@ def make_test_method(
         task_id=task_id,
         config_params=kwargs,
         padding=padding,
+        sweep=sweep,
         __getitem__=lambda _, k: kwargs[k],  # return kwargs value from dict access
     )
 


### PR DESCRIPTION
Fixes #418 

Auto insertion works after a `sweep` method added AND if the reconstruction method is present it would also add another `save_to_images` method after it. This is due to users usually want to assess the change in the reconstructed images and not in projections or sinograms. Because of this, even if there is only one `sweep` method is present, `save_to_images` substitutions can be two. 
Tests added to test this, and also two pipelines added as tests. 
Yaml checker also changed  to check if `save_to_images` present after `sweep` methods and prompts a user to remove them as they are unnecessary. 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
