### PR TITLE
Fixing OOM issue

### DIFF
--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -333,8 +333,8 @@ class TaskRunner:
         max_slices_methods = [max_slices] * len(section)
 
         # NOTE: as the convertion of the raw data from uint16 to float32 happens after the data gets loaded,
-        # we should consider self.source.dtype to be float for memeory estimators. This should change later
-        # when the direct memory estimators will be able to tackle the change of data type.
+        # we should consider self.source.dtype to be float for memory estimators. This should change later
+        # when we deal with a possibility of data blocks being of different data type.
 
         # loop over all methods in section
         for idx, m in enumerate(section):

--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -301,7 +301,7 @@ class TaskRunner:
 
         data_shape = self.source.chunk_shape
         max_slices = data_shape[slicing_dim]
-
+        
         # loop over all methods in section
         has_gpu = False
         for idx, m in enumerate(section):
@@ -332,6 +332,10 @@ class TaskRunner:
 
         max_slices_methods = [max_slices] * len(section)
 
+        # NOTE: as the convertion of the raw data from uint16 to float32 happens after the data gets loaded,
+        # we should consider self.source.dtype to be float for memeory estimators. This should change later
+        # when the direct memory estimators will be able to tackle the change of data type.
+
         # loop over all methods in section
         for idx, m in enumerate(section):
             if len(m.memory_gpu) == 0:
@@ -340,7 +344,7 @@ class TaskRunner:
 
             output_dims = m.calculate_output_dims(non_slice_dims_shape)
             (slices_estimated, available_memory) = m.calculate_max_slices(
-                self.source.dtype,
+                np.dtype('float32'), # self.source.dtype, # see the NOTE about the dtype above
                 non_slice_dims_shape,
                 available_memory,
             )

--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -301,7 +301,6 @@ class TaskRunner:
 
         data_shape = self.source.chunk_shape
         max_slices = data_shape[slicing_dim]
-        
         # loop over all methods in section
         has_gpu = False
         for idx, m in enumerate(section):
@@ -332,9 +331,10 @@ class TaskRunner:
 
         max_slices_methods = [max_slices] * len(section)
 
+        SOURCE_DTYPE = np.dtype("float32")
         # NOTE: as the convertion of the raw data from uint16 to float32 happens after the data gets loaded,
-        # we should consider self.source.dtype to be float for memory estimators. This should change later
-        # when we deal with a possibility of data blocks being of different data type.
+        # we should consider self.source.dtype to be float for memory estimators.
+        # see https://github.com/DiamondLightSource/httomo/issues/440
 
         # loop over all methods in section
         for idx, m in enumerate(section):
@@ -344,7 +344,7 @@ class TaskRunner:
 
             output_dims = m.calculate_output_dims(non_slice_dims_shape)
             (slices_estimated, available_memory) = m.calculate_max_slices(
-                np.dtype('float32'), # self.source.dtype, # see the NOTE about the dtype above
+                SOURCE_DTYPE,  # self.source.dtype,
                 non_slice_dims_shape,
                 available_memory,
             )


### PR DESCRIPTION
Fixes #437 

Slightly hacky fix for #437 to deal with the fact that the conversion to float32 happens after the data gets loaded. We should   essentially ignore `source.dtype`.  I wrote more about it in #436, but may be a separate issue should exist to deal with this in future separately from the library changes. 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
