### PR TITLE
Update pipelines to match changes to image saver and rescaler methods

### DIFF
--- a/httomo/transform_layer.py
+++ b/httomo/transform_layer.py
@@ -92,8 +92,6 @@ class TransformLayer:
                         task_id=f"saveimage_sweep_{m.task_id}",
                         subfolder_name="images_sweep_" + str(m.method_name),
                         axis=1,
-                        perc_range_min=5,
-                        perc_range_max=95,
                     ),
                 )
                 sweep_before = True

--- a/httomo/transform_layer.py
+++ b/httomo/transform_layer.py
@@ -73,15 +73,28 @@ class TransformLayer:
         return Pipeline(loader, methods)
 
     def insert_save_images_after_sweep(self, pipeline: Pipeline) -> Pipeline:
-        """For sweep methods we add image saving method after.
-        In addition we also add saving the results of the reconstruction,
-        if the module is present"""
+        """For sweep methods we add image saving method after, and also a rescaling method to
+        rescale the data passed to the image saver. In addition we also add saving the results
+        of the reconstruction, if the module is present"""
         loader = pipeline.loader
         methods = []
         sweep_before = False
         for m in pipeline:
             methods.append(m)
             if m.sweep or "recon" in m.module_path and sweep_before:
+                methods.append(
+                    make_method_wrapper(
+                        self._repo,
+                        "httomolibgpu.misc.rescale",
+                        "rescale_to_int",
+                        comm=self._comm,
+                        save_result=False,
+                        task_id=f"rescale_sweep_{m.task_id}",
+                        perc_range_min=0.0,
+                        perc_range_max=100.0,
+                        bits=8,
+                    )
+                )
                 methods.append(
                     make_method_wrapper(
                         self._repo,

--- a/tests/samples/pipeline_template_examples/DLS/01_diad_pipeline_gpu.yaml
+++ b/tests/samples/pipeline_template_examples/DLS/01_diad_pipeline_gpu.yaml
@@ -56,14 +56,17 @@
   id: statistics
   side_outputs:
     glob_stats: glob_stats
+- method: rescale_to_int
+  module_path: httomolibgpu.misc.rescale
+  parameters:
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    bits: 8
+    glob_stats: ${{statistics.side_outputs.glob_stats}}
 - method: save_to_images
   module_path: httomolib.misc.images
   parameters:
     subfolder_name: images
     axis: auto
     file_format: tif
-    bits: 8
-    perc_range_min: 0.0
-    perc_range_max: 95.0
     jpeg_quality: 95
-    glob_stats: ${{statistics.side_outputs.glob_stats}}

--- a/tests/samples/pipeline_template_examples/pipeline_360deg_gpu2.yaml
+++ b/tests/samples/pipeline_template_examples/pipeline_360deg_gpu2.yaml
@@ -63,14 +63,17 @@
   id: statistics
   side_outputs:
     glob_stats: glob_stats
+- method: rescale_to_int
+  module_path: httomolibgpu.misc.rescale
+  parameters:
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    bits: 8
+    glob_stats: ${{statistics.side_outputs.glob_stats}}
 - method: save_to_images
   module_path: httomolib.misc.images
   parameters:
     subfolder_name: images
     axis: auto
     file_format: tif
-    bits: 8
-    perc_range_min: 0.0
-    perc_range_max: 95.0
     jpeg_quality: 95
-    glob_stats: ${{statistics.side_outputs.glob_stats}}

--- a/tests/samples/pipeline_template_examples/pipeline_cpu1.yaml
+++ b/tests/samples/pipeline_template_examples/pipeline_cpu1.yaml
@@ -34,13 +34,16 @@
     sinogram_order: false
     algorithm: 'gridrec'
     init_recon: null
+- method: rescale_to_int
+  module_path: httomolibgpu.misc.rescale
+  parameters:
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    bits: 8
 - method: save_to_images
   module_path: httomolib.misc.images
   parameters:
     subfolder_name: images
     axis: auto
     file_format: tif
-    bits: 8
-    perc_range_min: 0.0
-    perc_range_max: 100.0
     jpeg_quality: 95

--- a/tests/samples/pipeline_template_examples/pipeline_cpu2.yaml
+++ b/tests/samples/pipeline_template_examples/pipeline_cpu2.yaml
@@ -58,13 +58,16 @@
   parameters:
     size: 3
     axis: auto
+- method: rescale_to_int
+  module_path: httomolibgpu.misc.rescale
+  parameters:
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    bits: 8
 - method: save_to_images
   module_path: httomolib.misc.images
   parameters:
     subfolder_name: images
     axis: auto
     file_format: tif
-    bits: 8
-    perc_range_min: 0.0
-    perc_range_max: 100.0
     jpeg_quality: 95

--- a/tests/samples/pipeline_template_examples/pipeline_cpu3.yaml
+++ b/tests/samples/pipeline_template_examples/pipeline_cpu3.yaml
@@ -47,15 +47,17 @@
   id: statistics
   side_outputs:
     glob_stats: glob_stats
+- method: rescale_to_int
+  module_path: httomolibgpu.misc.rescale
+  parameters:
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    bits: 8
+    glob_stats: ${{statistics.side_outputs.glob_stats}}
 - method: save_to_images
   module_path: httomolib.misc.images
   parameters:
     subfolder_name: images
     axis: auto
     file_format: tif
-    bits: 8
-    perc_range_min: 0.0
-    perc_range_max: 100.0
     jpeg_quality: 95
-    glob_stats: ${{statistics.side_outputs.glob_stats}}
-

--- a/tests/samples/pipeline_template_examples/pipeline_cpu4.yaml
+++ b/tests/samples/pipeline_template_examples/pipeline_cpu4.yaml
@@ -31,13 +31,16 @@
     sinogram_order: false
     algorithm: 'gridrec'
     init_recon: null
+- method: rescale_to_int
+  module_path: httomolibgpu.misc.rescale
+  parameters:
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    bits: 8
 - method: save_to_images
   module_path: httomolib.misc.images
   parameters:
     subfolder_name: images
     axis: auto
     file_format: tif
-    bits: 8
-    perc_range_min: 0.0
-    perc_range_max: 100.0
     jpeg_quality: 95

--- a/tests/samples/pipeline_template_examples/pipeline_gpu1.yaml
+++ b/tests/samples/pipeline_template_examples/pipeline_gpu1.yaml
@@ -46,13 +46,16 @@
     recon_size: null
     recon_mask_radius: null
   save_result: true
+- method: rescale_to_int
+  module_path: httomolibgpu.misc.rescale
+  parameters:
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    bits: 8
 - method: save_to_images
   module_path: httomolib.misc.images
   parameters:
     subfolder_name: images
     axis: auto
     file_format: tif
-    bits: 8
-    perc_range_min: 0.0
-    perc_range_max: 100.0
     jpeg_quality: 95

--- a/tests/samples/pipeline_template_examples/testing/testing_pipeline.yaml
+++ b/tests/samples/pipeline_template_examples/testing/testing_pipeline.yaml
@@ -34,13 +34,16 @@
     algorithm: gridrec
     init_recon: null
   save_result: true
+- method: rescale_to_int
+  module_path: httomolibgpu.misc.rescale
+  parameters:
+    perc_range_min: 0.0
+    perc_range_max: 100.0
+    bits: 8
 - method: save_to_images
   module_path: httomolib.misc.images
   parameters:
     subfolder_name: images
     axis: 1
     file_format: tif
-    bits: 8
-    perc_range_min: 0.0
-    perc_range_max: 100.0
     jpeg_quality: 95

--- a/tests/samples/python_templates/pipeline_cpu1.py
+++ b/tests/samples/python_templates/pipeline_cpu1.py
@@ -73,18 +73,25 @@ def methods_to_list() -> PipelineConfig:
     }
     full_pipeline_list.append(method4)
     method5 = {
+        "method": "rescale_to_int",
+        "module_path": "httomolibgpu.misc.rescale",
+        "parameters": {
+            "perc_range_min": 0.0,
+            "perc_range_max": 100.0,
+            "bits": 8,
+        },
+    }
+    full_pipeline_list.append(method5)
+    method6 = {
         "method": "save_to_images",
         "module_path": "httomolib.misc.images",
         "parameters": {
             "subfolder_name": "images",
             "axis": 1,
             "file_format": "tif",
-            "bits": 8,
-            "perc_range_min": 0.0,
-            "perc_range_max": 100.0,
             "jpeg_quality": 95,
         },
     }
-    full_pipeline_list.append(method5)
+    full_pipeline_list.append(method6)
 
     return full_pipeline_list

--- a/tests/samples/python_templates/pipeline_cpu2.py
+++ b/tests/samples/python_templates/pipeline_cpu2.py
@@ -105,18 +105,25 @@ def methods_to_list() -> PipelineConfig:
     }
     full_pipeline_list.append(method7)
     method8 = {
+        "method": "rescale_to_int",
+        "module_path": "httomolibgpu.misc.rescale",
+        "parameters": {
+            "perc_range_min": 0.0,
+            "perc_range_max": 100.0,
+            "bits": 8,
+        },
+    }
+    full_pipeline_list.append(method8)
+    method9 = {
         "method": "save_to_images",
         "module_path": "httomolib.misc.images",
         "parameters": {
             "subfolder_name": "images",
             "axis": 1,
             "file_format": "tif",
-            "bits": 8,
-            "perc_range_min": 0.0,
-            "perc_range_max": 100.0,
             "jpeg_quality": 95,
         },
     }
-    full_pipeline_list.append(method8)
+    full_pipeline_list.append(method9)
 
     return full_pipeline_list

--- a/tests/samples/python_templates/pipeline_cpu3.py
+++ b/tests/samples/python_templates/pipeline_cpu3.py
@@ -91,19 +91,26 @@ def methods_to_list() -> PipelineConfig:
     }
     full_pipeline_list.append(method6)
     method7 = {
+        "method": "rescale_to_int",
+        "module_path": "httomolibgpu.misc.rescale",
+        "parameters": {
+            "perc_range_min": 0.0,
+            "perc_range_max": 100.0,
+            "bits": 8,
+            "glob_stats": "${{statistics.side_outputs.glob_stats}}",
+        },
+    }
+    full_pipeline_list.append(method7)
+    method8 = {
         "method": "save_to_images",
         "module_path": "httomolib.misc.images",
         "parameters": {
             "subfolder_name": "images",
             "axis": 1,
             "file_format": "tif",
-            "bits": 8,
-            "perc_range_min": 0.0,
-            "perc_range_max": 100.0,
             "jpeg_quality": 95,
-            "glob_stats": "${{statistics.side_outputs.glob_stats}}",
         },
     }
-    full_pipeline_list.append(method7)
+    full_pipeline_list.append(method8)
 
     return full_pipeline_list

--- a/tests/samples/python_templates/pipeline_gpu1.py
+++ b/tests/samples/python_templates/pipeline_gpu1.py
@@ -88,18 +88,25 @@ def methods_to_list() -> PipelineConfig:
     }
     full_pipeline_list.append(method5)
     method6 = {
+        "method": "rescale_to_int",
+        "module_path": "httomolibgpu.misc.rescale",
+        "parameters": {
+            "perc_range_min": 0.0,
+            "perc_range_max": 100.0,
+            "bits": 8,
+        },
+    }
+    full_pipeline_list.append(method6)
+    method7 = {
         "method": "save_to_images",
         "module_path": "httomolib.misc.images",
         "parameters": {
             "subfolder_name": "images",
             "axis": 1,
             "file_format": "tif",
-            "bits": 8,
-            "perc_range_min": 0.0,
-            "perc_range_max": 100.0,
             "jpeg_quality": 95,
         },
     }
-    full_pipeline_list.append(method6)
+    full_pipeline_list.append(method7)
 
     return full_pipeline_list

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -454,14 +454,14 @@ def test_tomo_standard_testing_pipeline_output_with_save_all(
     subprocess.check_output(cmd)
 
     files = get_files("output_dir/")
-    assert len(files) == 10
+    assert len(files) == 11
 
     _check_yaml(files, "temp.yaml")
     _check_tif(files, 3, (160, 160))
 
     #: check the generated h5 files
     h5_files = list(filter(lambda x: ".h5" in x, files))
-    assert len(h5_files) == 4
+    assert len(h5_files) == 5
 
     for file_to_open in h5_files:
         if "tomopy-recon-tomo-gridrec.h5" in file_to_open:
@@ -488,7 +488,7 @@ def test_i12_testing_pipeline_output(
     subprocess.check_output(cmd)
 
     files = get_files("output_dir/")
-    assert len(files) == 17
+    assert len(files) == 18
 
     _check_yaml(files, "temp.yaml")
 
@@ -499,7 +499,7 @@ def test_i12_testing_pipeline_output(
     assert len(tif_files) == 10
 
     h5_files = list(filter(lambda x: ".h5" in x, files))
-    assert len(h5_files) == 4
+    assert len(h5_files) == 5
 
     gridrec_recon = list(filter(lambda x: "recon-gridrec.h5" in x, h5_files))[0]
     minus_log_tomo = list(filter(lambda x: "minus_log.h5" in x, h5_files))[0]
@@ -600,14 +600,14 @@ def test_diad_testing_pipeline_output(
     subprocess.check_output(cmd)
 
     files = get_files("output_dir/")
-    assert len(files) == 9
+    assert len(files) == 10
 
     _check_yaml(files, "temp.yaml")
     _check_tif(files, 2, (26, 26))
 
     #: check the generated h5 files
     h5_files = list(filter(lambda x: ".h5" in x, files))
-    assert len(h5_files) == 4
+    assert len(h5_files) == 5
 
     for file_to_open in h5_files:
         if "tomopy-normalize-tomo.h5" in file_to_open:

--- a/tests/test_transform_layer.py
+++ b/tests/test_transform_layer.py
@@ -179,14 +179,19 @@ def test_insert_image_save_after_sweep(mocker: MockerFixture, tmp_path: Path):
     trans = TransformLayer(comm, repo=repo, save_all=False, out_dir=tmp_path)
     pipeline = trans.insert_save_images_after_sweep(pipeline)
 
-    assert len(pipeline) == 4
-    assert pipeline[3].method_name == "save_to_images"
-    assert pipeline[3].task_id == "saveimage_sweep_t3"
+    assert len(pipeline) == 5
+    assert pipeline[3].method_name == "rescale_to_int"
+    assert pipeline[3].task_id == "rescale_sweep_t3"
+    assert pipeline[3].config_params["perc_range_min"] == 0.0
+    assert pipeline[3].config_params["perc_range_max"] == 100.0
+    assert pipeline[3].config_params["bits"] == 8
+    assert pipeline[4].method_name == "save_to_images"
+    assert pipeline[4].task_id == "saveimage_sweep_t3"
     assert (
-        pipeline[3].config_params["subfolder_name"]
+        pipeline[4].config_params["subfolder_name"]
         == "images_sweep_paganin_filter_tomopy"
     )
-    assert pipeline[3].config_params["axis"] == 1
+    assert pipeline[4].config_params["axis"] == 1
 
 
 def test_insert_image_save_after_sweep2(mocker: MockerFixture, tmp_path: Path):
@@ -233,15 +238,25 @@ def test_insert_image_save_after_sweep2(mocker: MockerFixture, tmp_path: Path):
     trans = TransformLayer(comm, repo=repo, save_all=False, out_dir=tmp_path)
     pipeline = trans.insert_save_images_after_sweep(pipeline)
 
-    assert len(pipeline) == 6
-    assert pipeline[3].method_name == "save_to_images"
-    assert pipeline[3].task_id == "saveimage_sweep_t3"
+    assert len(pipeline) == 8
+    assert pipeline[3].method_name == "rescale_to_int"
+    assert pipeline[3].task_id == "rescale_sweep_t3"
+    assert pipeline[3].config_params["perc_range_min"] == 0.0
+    assert pipeline[3].config_params["perc_range_max"] == 100.0
+    assert pipeline[3].config_params["bits"] == 8
+    assert pipeline[4].method_name == "save_to_images"
+    assert pipeline[4].task_id == "saveimage_sweep_t3"
     assert (
-        pipeline[3].config_params["subfolder_name"]
+        pipeline[4].config_params["subfolder_name"]
         == "images_sweep_paganin_filter_tomopy"
     )
-    assert pipeline[3].config_params["axis"] == 1
-    assert pipeline[5].method_name == "save_to_images"
-    assert pipeline[5].task_id == "saveimage_sweep_t4"
-    assert pipeline[5].config_params["subfolder_name"] == "images_sweep_FBP"
-    assert pipeline[5].config_params["axis"] == 1
+
+    assert pipeline[6].method_name == "rescale_to_int"
+    assert pipeline[6].task_id == "rescale_sweep_t4"
+    assert pipeline[6].config_params["perc_range_min"] == 0.0
+    assert pipeline[6].config_params["perc_range_max"] == 100.0
+    assert pipeline[6].config_params["bits"] == 8
+    assert pipeline[7].method_name == "save_to_images"
+    assert pipeline[7].task_id == "saveimage_sweep_t4"
+    assert pipeline[7].config_params["subfolder_name"] == "images_sweep_FBP"
+    assert pipeline[7].config_params["axis"] == 1

--- a/tests/test_ui_layer.py
+++ b/tests/test_ui_layer.py
@@ -19,7 +19,7 @@ def test_can_read_cpu1_python(python_cpu_pipeline1, yaml_cpu_pipeline1, version)
     else:
         pipline_stage_config = ui_layer.yaml_loader(yaml_cpu_pipeline1)
 
-    assert len(pipline_stage_config) == 6
+    assert len(pipline_stage_config) == 7
     assert pipline_stage_config[0]["method"] == "standard_tomo"
     assert pipline_stage_config[0]["module_path"] == "httomo.data.hdf.loaders"
     assert pipline_stage_config[1]["method"] == "normalize"
@@ -30,9 +30,11 @@ def test_can_read_cpu1_python(python_cpu_pipeline1, yaml_cpu_pipeline1, version)
     assert pipline_stage_config[3]["module_path"] == "tomopy.recon.rotation"
     assert pipline_stage_config[3]["side_outputs"] == {"cor": "centre_of_rotation"}
     assert pipline_stage_config[4]["method"] == "recon"
+    assert pipline_stage_config[5]["method"] == "rescale_to_int"
+    assert pipline_stage_config[5]["module_path"] == "httomolibgpu.misc.rescale"
     assert pipline_stage_config[4]["module_path"] == "tomopy.recon.algorithm"
-    assert pipline_stage_config[5]["method"] == "save_to_images"
-    assert pipline_stage_config[5]["module_path"] == "httomolib.misc.images"
+    assert pipline_stage_config[6]["method"] == "save_to_images"
+    assert pipline_stage_config[6]["module_path"] == "httomolib.misc.images"
 
 
 @pytest.mark.parametrize("version", ["python", "yaml"])
@@ -42,7 +44,7 @@ def test_can_read_cpu2_python(python_cpu_pipeline2, yaml_cpu_pipeline2, version)
     else:
         pipline_stage_config = ui_layer.yaml_loader(yaml_cpu_pipeline2)
 
-    assert len(pipline_stage_config) == 9
+    assert len(pipline_stage_config) == 10
     assert pipline_stage_config[0]["method"] == "standard_tomo"
     assert pipline_stage_config[0]["module_path"] == "httomo.data.hdf.loaders"
     assert pipline_stage_config[0]["parameters"]["preview"] == {
@@ -64,8 +66,10 @@ def test_can_read_cpu2_python(python_cpu_pipeline2, yaml_cpu_pipeline2, version)
     assert pipline_stage_config[6]["save_result"] == True
     assert pipline_stage_config[7]["method"] == "median_filter"
     assert pipline_stage_config[7]["module_path"] == "tomopy.misc.corr"
-    assert pipline_stage_config[8]["method"] == "save_to_images"
-    assert pipline_stage_config[8]["module_path"] == "httomolib.misc.images"
+    assert pipline_stage_config[8]["method"] == "rescale_to_int"
+    assert pipline_stage_config[8]["module_path"] == "httomolibgpu.misc.rescale"
+    assert pipline_stage_config[9]["method"] == "save_to_images"
+    assert pipline_stage_config[9]["module_path"] == "httomolib.misc.images"
 
 
 @pytest.mark.parametrize("version", ["python", "yaml"])
@@ -75,7 +79,7 @@ def test_can_read_cpu3_python(python_cpu_pipeline3, yaml_cpu_pipeline3, version)
     else:
         pipline_stage_config = ui_layer.yaml_loader(yaml_cpu_pipeline3)
 
-    assert len(pipline_stage_config) == 8
+    assert len(pipline_stage_config) == 9
     assert pipline_stage_config[0]["method"] == "standard_tomo"
     assert pipline_stage_config[0]["module_path"] == "httomo.data.hdf.loaders"
     assert pipline_stage_config[1]["method"] == "find_center_vo"
@@ -92,8 +96,10 @@ def test_can_read_cpu3_python(python_cpu_pipeline3, yaml_cpu_pipeline3, version)
     assert pipline_stage_config[6]["method"] == "calculate_stats"
     assert pipline_stage_config[6]["module_path"] == "httomo.methods"
     assert pipline_stage_config[6]["side_outputs"] == {"glob_stats": "glob_stats"}
-    assert pipline_stage_config[7]["method"] == "save_to_images"
-    assert pipline_stage_config[7]["module_path"] == "httomolib.misc.images"
+    assert pipline_stage_config[7]["method"] == "rescale_to_int"
+    assert pipline_stage_config[7]["module_path"] == "httomolibgpu.misc.rescale"
+    assert pipline_stage_config[8]["method"] == "save_to_images"
+    assert pipline_stage_config[8]["module_path"] == "httomolib.misc.images"
 
 
 @pytest.mark.parametrize("version", ["python", "yaml"])
@@ -103,7 +109,7 @@ def test_can_read_gpu1_python(python_gpu_pipeline1, yaml_gpu_pipeline1, version)
     else:
         pipline_stage_config = ui_layer.yaml_loader(yaml_gpu_pipeline1)
 
-    assert len(pipline_stage_config) == 7
+    assert len(pipline_stage_config) == 8
     assert pipline_stage_config[0]["method"] == "standard_tomo"
     assert pipline_stage_config[0]["module_path"] == "httomo.data.hdf.loaders"
     assert pipline_stage_config[1]["method"] == "find_center_vo"
@@ -117,8 +123,10 @@ def test_can_read_gpu1_python(python_gpu_pipeline1, yaml_gpu_pipeline1, version)
     assert pipline_stage_config[4]["module_path"] == "httomolibgpu.prep.stripe"
     assert pipline_stage_config[5]["method"] == "FBP"
     assert pipline_stage_config[5]["module_path"] == "httomolibgpu.recon.algorithm"
-    assert pipline_stage_config[6]["method"] == "save_to_images"
-    assert pipline_stage_config[6]["module_path"] == "httomolib.misc.images"
+    assert pipline_stage_config[6]["method"] == "rescale_to_int"
+    assert pipline_stage_config[6]["module_path"] == "httomolibgpu.misc.rescale"
+    assert pipline_stage_config[7]["method"] == "save_to_images"
+    assert pipline_stage_config[7]["module_path"] == "httomolib.misc.images"
 
 
 @pytest.mark.parametrize("extension", ["yaml", "yml", "YaML", "YAML"])
@@ -200,8 +208,15 @@ def test_pipeline_build_cpu1(
 
     pipeline = LayerUI.build_pipeline()
 
-    assert len(pipeline) == 5
-    methods = ["normalize", "minus_log", "find_center_vo", "recon", "save_to_images"]
+    assert len(pipeline) == 6
+    methods = [
+        "normalize",
+        "minus_log",
+        "find_center_vo",
+        "recon",
+        "rescale_to_int",
+        "save_to_images",
+    ]
     for i in range(5):
         assert pipeline[i].method_name == methods[i]
         if i != 2:
@@ -229,7 +244,7 @@ def test_pipeline_build_cpu2(
 
     pipeline = LayerUI.build_pipeline()
 
-    assert len(pipeline) == 8
+    assert len(pipeline) == 9
     methods = [
         "find_center_vo",
         "remove_outlier",
@@ -238,6 +253,7 @@ def test_pipeline_build_cpu2(
         "remove_stripe_fw",
         "recon",
         "median_filter",
+        "rescale_to_int",
         "save_to_images",
     ]
     for i in range(8):
@@ -263,7 +279,7 @@ def test_pipeline_build_cpu3(
 
     pipeline = LayerUI.build_pipeline()
 
-    assert len(pipeline) == 7
+    assert len(pipeline) == 8
     methods = [
         "find_center_vo",
         "remove_outlier",
@@ -271,9 +287,10 @@ def test_pipeline_build_cpu3(
         "minus_log",
         "recon",
         "calculate_stats",
+        "rescale_to_int",
         "save_to_images",
     ]
-    for i in range(7):
+    for i in range(8):
         assert pipeline[i].method_name == methods[i]
     ref = pipeline[6]["glob_stats"]
     assert isinstance(ref, OutputRef)


### PR DESCRIPTION
These changes are needed on the httomo side to accommodate when the following changes are released in httomolib and httomolibgpu (ie, when these changes make their way into the conda packages that httomo installs during CI):
- https://github.com/DiamondLightSource/httomolibgpu/pull/157
- https://github.com/DiamondLightSource/httomolib/pull/17

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
