### PR TITLE
Add CLI flag to pass an existing output directory to httomo (instead of httomo creating one)

### DIFF
--- a/docs/source/howto/run_httomo.rst
+++ b/docs/source/howto/run_httomo.rst
@@ -155,21 +155,37 @@ The :code:`run` command
       Run a pipeline defined in YAML on input data.
 
     Options:
-      --save-all                 Save intermediate datasets for all tasks in the
-                                 pipeline.
-      --gpu-id INTEGER           The GPU ID of the device to use.
-      --reslice-dir DIRECTORY    Directory for temporary files potentially needed
-                                 for reslicing (defaults to output dir)
-      --max-cpu-slices INTEGER   Maximum number of slices to use for a block for
-                                 CPU-only sections (default: 64)
-      --max-memory TEXT          Limit the amount of memory used by the pipeline
-                                 to the given memory (supports strings like 3.2G
-                                 or bytes)
-      --monitor TEXT             Add monitor to the runner (can be given multiple
-                                 times). Available monitors: bench, summary
-      --monitor-output FILENAME  File to store the monitoring output. Defaults to
-                                 '-', which denotes stdout
-      --help                     Show this message and exit.
+      --output-folder-name DIRECTORY  Define the name of the output folder created
+                                      by HTTomo
+      --output-folder-path DIRECTORY  Provide path to folder in which output
+                                      should be stored. This overrides the
+                                      `out_dir` argument
+      --save-all                      Save intermediate datasets for all tasks in
+                                      the pipeline.
+      --gpu-id INTEGER                The GPU ID of the device to use.
+      --reslice-dir DIRECTORY         Directory for temporary files potentially
+                                      needed for reslicing (defaults to output
+                                      dir)
+      --max-cpu-slices INTEGER        Maximum number of slices to use for a block
+                                      for CPU-only sections (default: 64)
+      --max-memory TEXT               Limit the amount of memory used by the
+                                      pipeline to the given memory (supports
+                                      strings like 3.2G or bytes)
+      --monitor TEXT                  Add monitor to the runner (can be given
+                                      multiple times). Available monitors: bench,
+                                      summary
+      --monitor-output FILENAME       File to store the monitoring output.
+                                      Defaults to '-', which denotes stdout
+      --intermediate-format [hdf5]    Write intermediate data in hdf5 format
+      --compress-intermediate         Write intermediate data in chunked format
+                                      with BLOSC compression applied
+      --syslog-host TEXT              Host of the syslog server
+      --syslog-port INTEGER           Port on the host the syslog server is
+                                      running on
+      --frames-per-chunk INTEGER RANGE
+                                      Number of frames per-chunk in intermediate
+                                      data (0 = write as contiguous)  [x>=0]
+      --help                          Show this message and exit.
 
 Arguments
 #########
@@ -210,16 +226,34 @@ directory created by HTTomo would be
 Options/flags
 #############
 
-The :code:`run` command has 6 options/flags:
+The :code:`run` command has 14 options/flags:
 
+- :code:`--output-folder-name`
+- :code:`--output-folder-path`
 - :code:`--save-all`
+- :code:`--gpu-id`
 - :code:`--reslice-dir`
 - :code:`--max-cpu-slices`
 - :code:`--max-memory`
 - :code:`--monitor`
 - :code:`--monitor-output`
+- :code:`--intermediate-format`
+- :code:`--compress-intermediate`
+- :code:`--syslog-host`
+- :code:`--syslog-port`
+- :code:`--frames-per-chunk`
 
 .. _httomo-saving:
+
+:code:`--output-folder-name`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+:code:`--output-folder-path`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
 
 :code:`--save-all`
 ~~~~~~~~~~~~~~~~~~
@@ -236,6 +270,11 @@ following conditions is satisfied:
 However, there are certain cases such as debugging, where saving the output of
 all methods to files in the output directory is beneficial. This flag is a quick
 way of doing so.
+
+:code:`--gpu-id`
+~~~~~~~~~~~~~~~~
+
+TODO
 
 :code:`--reslice-dir`
 ~~~~~~~~~~~~~~~~~~~~~
@@ -377,3 +416,28 @@ analysis.
 HTTomo supports writing the monitoring results in CSV format, and so any given
 filepath to the :code:`--monitor-output` flag will produce a file with the
 benchmarking results written in CSV format.
+
+:code:`--intermediate-format`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+:code:`--compress-intermediate`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+:code:`--syslog-host`
+~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+:code:`--syslog-port`
+~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+:code:`--frames-per-chunk`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO

--- a/docs/source/howto/run_httomo.rst
+++ b/docs/source/howto/run_httomo.rst
@@ -260,7 +260,15 @@ created by HTTomo would be :code:`/home/myuser/test-1/`.
 :code:`--output-folder-path`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+If one wishes to have HTTomo *not* create an output directory, and instead for HTTomo to place
+the output in an existing directory, then the :code:`--output-folder-path` flag may be used.
+
+For example, if :code:`--output-folder-path=/home/myuser/my-output` was given, then HTTomo
+wouldn't create an output directory and would simply place the results in
+:code:`/home/myuser/my-output`.
+
+.. note:: This flag overrides the :code:`OUT_DIR` argument. Also, the given directory must
+          exist prior to running HTTomo
 
 :code:`--save-all`
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/howto/run_httomo.rst
+++ b/docs/source/howto/run_httomo.rst
@@ -248,7 +248,14 @@ The :code:`run` command has 14 options/flags:
 :code:`--output-folder-name`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+As described in the documentation for the :code:`OUT_DIR` argument, the default name of the
+output directory created by HTTomo consists primarily of a timestamp. If one wishes to provide
+a name for the directory created by HTTomo instead of using the default timestamp name, then
+the :code:`--output-folder-name` flag may be used to achieve this.
+
+For example, if the :code:`OUT_DIR` path provided was :code:`/home/myuser`, and
+:code:`--output-folder-name=test-1` was given, then the absolute path of the output directory
+created by HTTomo would be :code:`/home/myuser/test-1/`.
 
 :code:`--output-folder-path`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -68,6 +68,15 @@ def check(yaml_config: Path, in_data_file: Optional[Path] = None):
     help="Define the name of the output folder created by HTTomo",
 )
 @click.option(
+    "--output-folder-path",
+    type=click.Path(exists=True, file_okay=False, writable=True, path_type=Path),
+    default=None,
+    help=(
+        "Provide path to folder in which output should be stored. This overrides "
+        "the `out_dir` argument"
+    ),
+)
+@click.option(
     "--save-all",
     is_flag=True,
     help="Save intermediate datasets for all tasks in the pipeline.",
@@ -146,6 +155,7 @@ def run(
     yaml_config: Path,
     out_dir: Path,
     output_folder_name: Optional[Path],
+    output_folder_path: Optional[Path],
     gpu_id: int,
     save_all: bool,
     reslice_dir: Union[Path, None],
@@ -169,6 +179,7 @@ def run(
         syslog_host,
         syslog_port,
         output_folder_name,
+        output_folder_path,
     )
 
     does_contain_sweep = is_sweep_pipeline(yaml_config)
@@ -247,6 +258,7 @@ def set_global_constants(
     syslog_host: str,
     syslog_port: int,
     output_folder_name: Optional[Path],
+    output_folder_path: Optional[Path],
 ) -> None:
     if compress_intermediate:
         frames_per_chunk = 1
@@ -255,6 +267,13 @@ def set_global_constants(
     httomo.globals.FRAMES_PER_CHUNK = frames_per_chunk
     httomo.globals.SYSLOG_SERVER = syslog_host
     httomo.globals.SYSLOG_PORT = syslog_port
+
+    if output_folder_name is not None and output_folder_path is not None:
+        msg = (
+            "The flags `--output-folder-name` and `--output-folder-path` are mutually "
+            "exclusive, please use only one at most"
+        )
+        raise ValueError(msg)
 
     if output_folder_name is None:
         httomo.globals.run_out_dir = out_dir.joinpath(

--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -61,7 +61,7 @@ def check(yaml_config: Path, in_data_file: Optional[Path] = None):
     type=click.Path(exists=True, file_okay=False, writable=True, path_type=Path),
 )
 @click.option(
-    "--create-folder",
+    "--output-folder-name",
     type=click.Path(exists=False, file_okay=False, writable=True, path_type=Path),
     default=None,
     help="Define the name of the output folder created by HTTomo",
@@ -144,7 +144,7 @@ def run(
     in_data_file: Path,
     yaml_config: Path,
     out_dir: Path,
-    create_folder: Optional[Path],
+    output_folder_name: Optional[Path],
     gpu_id: int,
     save_all: bool,
     reslice_dir: Union[Path, None],
@@ -172,12 +172,12 @@ def run(
     httomo.globals.SYSLOG_PORT = syslog_port
 
     # Define httomo.globals.run_out_dir in all MPI processes
-    if create_folder is None:
+    if output_folder_name is None:
         httomo.globals.run_out_dir = out_dir.joinpath(
             f"{datetime.now().strftime('%d-%m-%Y_%H_%M_%S')}_output"
         )
     else:
-        httomo.globals.run_out_dir = out_dir.joinpath(create_folder)
+        httomo.globals.run_out_dir = out_dir.joinpath(output_folder_name)
 
     # Various initialisation tasks
     if global_comm.rank == 0:

--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -275,12 +275,14 @@ def set_global_constants(
         )
         raise ValueError(msg)
 
-    if output_folder_name is None:
+    if output_folder_name is None and output_folder_path is None:
         httomo.globals.run_out_dir = out_dir.joinpath(
             f"{datetime.now().strftime('%d-%m-%Y_%H_%M_%S')}_output"
         )
-    else:
+    if output_folder_name is not None:
         httomo.globals.run_out_dir = out_dir.joinpath(output_folder_name)
+    if output_folder_path is not None:
+        httomo.globals.run_out_dir = output_folder_path
 
     if max_cpu_slices < 1:
         raise ValueError("max-cpu-slices must be greater or equal to 1")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,5 +93,25 @@ def test_output_folder_name_correctly_sets_run_out_dir_global_constant(output_fo
         syslog_host="localhost",
         syslog_port=514,
         output_folder_name=Path(dir_name),
+        output_folder_path=None,
     )
     assert httomo.globals.run_out_dir == custom_output_dir
+
+
+def test_output_folder_name_and_path_flags_raise_error_if_both_provided():
+    with pytest.raises(ValueError) as e:
+        set_global_constants(
+            out_dir=Path("/"),
+            intermediate_format="hdf5",
+            compress_intermediate=False,
+            frames_per_chunk=0,
+            max_cpu_slices=1,
+            syslog_host="localhost",
+            syslog_port=514,
+            output_folder_name=Path("folder-1"),
+            output_folder_path=Path("/path/to/folder-2"),
+        )
+    assert (
+        "The flags `--output-folder-name` and `--output-folder-path` are mutually exclusive"
+        in str(e)
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,3 +115,19 @@ def test_output_folder_name_and_path_flags_raise_error_if_both_provided():
         "The flags `--output-folder-name` and `--output-folder-path` are mutually exclusive"
         in str(e)
     )
+
+
+def test_output_folder_path_correctly_sets_run_out_dir_global_constant():
+    output_folder_path = Path("/some/path/for/output")
+    set_global_constants(
+        out_dir=Path("/"),
+        intermediate_format="hdf5",
+        compress_intermediate=False,
+        frames_per_chunk=0,
+        max_cpu_slices=1,
+        syslog_host="localhost",
+        syslog_port=514,
+        output_folder_name=None,
+        output_folder_path=output_folder_path,
+    )
+    assert httomo.globals.run_out_dir == output_folder_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,7 +80,7 @@ def test_cli_fails_transforming_memory_limits(cli_parameter: str):
 
 
 @pytest.mark.cupy
-def test_cli_pass_create_folder(
+def test_cli_pass_output_folder_name(
     standard_data, standard_loader, testing_pipeline, merge_yamls, output_folder
 ):
     merge_yamls(standard_loader, testing_pipeline)
@@ -92,7 +92,7 @@ def test_cli_pass_create_folder(
         "-m",
         "httomo",
         "run",
-        "--create-folder",
+        "--output-folder-name",
         httomo_output_dir,
         standard_data,
         "temp.yaml",


### PR DESCRIPTION
Fixes #458

Also, this change has refactored `cli.py` a bit, separating the different groups of logic into their own functions. Doing that made it easier to test the output directory was being set as expected, and also made the test not need to run a pipeline just to check the setting for the output directory.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
