### PR TITLE
Update CUDA container version for IRIS CI tests

### DIFF
--- a/.github/workflows/run_tests_iris.yml
+++ b/.github/workflows/run_tests_iris.yml
@@ -12,7 +12,7 @@ jobs:
   iris-gpu:
     runs-on: iris-gpu
     container:
-      image: nvidia/cuda:11.6.2-devel-ubi8
+      image: nvidia/cuda:12.6.3-devel-ubi8
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
 

--- a/.github/workflows/run_tests_iris.yml
+++ b/.github/workflows/run_tests_iris.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create conda environment
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: conda/environment.yml
+          environment-file: conda/cuda-on-host.yml
           environment-name: httomo
           post-cleanup: 'all'
           init-shell: bash
@@ -36,8 +36,8 @@ jobs:
         run: |
           micromamba activate httomo
           pip install --upgrade --force-reinstall pillow
-          pip install httomolibgpu tomobar httomo-backends
-          pip install .         
+          pip install --no-deps httomolibgpu
+          pip install .[ci]
           micromamba list
                 
       - name: Run HTTomo tests

--- a/conda/cuda-on-host.yml
+++ b/conda/cuda-on-host.yml
@@ -1,0 +1,7 @@
+name: httomo
+channels:
+  - conda-forge
+dependencies:
+  - h5py=*=*mpi_openmpi*
+  - mpi4py
+  - tomopy=1.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,17 @@ dev-gpu = [
   "types-PyYAML",
   "pre-commit"
 ]
+ci = [
+    "astra-toolbox",
+    "cupy-cuda12x",
+    "hdf5plugin",
+    "nvtx",
+    "plumbum",
+    "pytest",
+    "pytest-mock",
+    "pytest-xdist",
+    "tomobar",
+]
 
 [tool.mypy]
 # Ignore missing stubs for modules we use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "click",
-    "numpy",
+    "numpy < 2",
     "httomolib",
     "httomo-backends",
     "loguru",


### PR DESCRIPTION
Tentatively updating CUDA version due to seeing that this somehow got rid of the cupy/CUDA errors appearing in https://github.com/DiamondLightSource/httomo-backends/pull/6

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
