### PR TITLE
Decide the value of frames_per_chunk from saturation bandwidth

### DIFF
--- a/docs/source/howto/run_httomo.rst
+++ b/docs/source/howto/run_httomo.rst
@@ -181,7 +181,8 @@ The :code:`run` command
                                       running on
       --frames-per-chunk INTEGER RANGE
                                       Number of frames per-chunk in intermediate
-                                      data (0 = write as contiguous)  [x>=0]
+                                      data (0 = write as contiguous, -1 = decide
+                                      automatically)  [x>=-1]
       --help                          Show this message and exit.
 
 Arguments
@@ -438,4 +439,12 @@ TODO
 :code:`--frames-per-chunk`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+This flag sets the number of frames in a chunk for the intermediate file.
+
+- -1 (the default), it will be decided automatically;
+- 0, continguous storage will be used (no chunk storage);
+- >= 1, the number of frames in a chunk.
+
+For most cases the default -1 should be sufficient as the actual number of
+frames in a chunk is optimised by considering the saturation bandwidth of the
+filesystem.

--- a/docs/source/howto/run_httomo.rst
+++ b/docs/source/howto/run_httomo.rst
@@ -442,7 +442,7 @@ TODO
 This flag sets the number of frames in a chunk for the intermediate file.
 
 - -1 (the default), it will be decided automatically;
-- 0, continguous storage will be used (no chunk storage);
+- 0, contiguous storage will be used (no chunk storage);
 - >= 1, the number of frames in a chunk.
 
 For most cases the default -1 should be sufficient as the actual number of

--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -138,9 +138,11 @@ def check(yaml_config: Path, in_data_file: Optional[Path] = None):
 @click.option(
     "--frames-per-chunk",
     type=click.IntRange(-1),
-    default=1,
-    help=("Number of frames per-chunk in intermediate data "
-          "(0 = write as contiguous, -1 = decide automatically)"),
+    default=-1,
+    help=(
+        "Number of frames per-chunk in intermediate data "
+        "(0 = write as contiguous, -1 = decide automatically)"
+    ),
 )
 def run(
     in_data_file: Path,

--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -137,9 +137,10 @@ def check(yaml_config: Path, in_data_file: Optional[Path] = None):
 )
 @click.option(
     "--frames-per-chunk",
-    type=click.IntRange(0),
+    type=click.IntRange(-1),
     default=1,
-    help="Number of frames per-chunk in intermediate data (0 = write as contiguous)",
+    help=("Number of frames per-chunk in intermediate data "
+          "(0 = write as contiguous, -1 = decide automatically)"),
 )
 def run(
     in_data_file: Path,

--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -249,8 +249,10 @@ def set_global_constants(
     syslog_port: int,
     output_folder_name: Optional[Path],
 ) -> None:
-    if compress_intermediate:
-        frames_per_chunk = 1
+    if compress_intermediate and frames_per_chunk == 0:
+        # 0 means write contiguously but compression must have chunk
+        # storage, so decide automatically in this case
+        frames_per_chunk = -1
     httomo.globals.INTERMEDIATE_FORMAT = intermediate_format
     httomo.globals.COMPRESS_INTERMEDIATE = compress_intermediate
     httomo.globals.FRAMES_PER_CHUNK = frames_per_chunk

--- a/httomo/globals.py
+++ b/httomo/globals.py
@@ -7,7 +7,9 @@ gpu_id: int = -1
 MAX_CPU_SLICES: int = (
     64  # A some random number which will be overwritten by --max-cpu_slices flag during runtime
 )
-FRAMES_PER_CHUNK: int = 1  # if given as 0, then write contiguous (no chunking); if given as -1, decide automatically
+FRAMES_PER_CHUNK: int = (
+    -1
+)  # if given as 0, then write contiguous (no chunking); if given as -1, decide automatically
 INTERMEDIATE_FORMAT: str = "hdf5"
 COMPRESS_INTERMEDIATE: bool = False
 SYSLOG_SERVER = "localhost"

--- a/httomo/globals.py
+++ b/httomo/globals.py
@@ -7,7 +7,7 @@ gpu_id: int = -1
 MAX_CPU_SLICES: int = (
     64  # A some random number which will be overwritten by --max-cpu_slices flag during runtime
 )
-FRAMES_PER_CHUNK: int = 1  # if given as 0, then write contiguous (no chunking)
+FRAMES_PER_CHUNK: int = 1  # if given as 0, then write contiguous (no chunking); if given as -1, decide automatically
 INTERMEDIATE_FORMAT: str = "hdf5"
 COMPRESS_INTERMEDIATE: bool = False
 SYSLOG_SERVER = "localhost"

--- a/httomo/methods.py
+++ b/httomo/methods.py
@@ -84,12 +84,13 @@ def setup_dataset(
 ) -> h5py.Dataset:
 
     if filetype == "hdf5":
+        DIMS = [0, 1, 2]
+        non_slicing_dims = list(set(DIMS) - set([slicing_dim]))
+
         if frames_per_chunk == -1:
             # decide the number of frames in a chunk by maximising the
             # number of frames around the saturation bandwidth of the
             # file system
-            DIMS = [0, 1, 2]
-            non_slicing_dims = list(set(DIMS) - set([slicing_dim]))
             # starting value
             sz_per_chunk = data.dtype.itemsize
             for dim in non_slicing_dims:
@@ -111,8 +112,6 @@ def setup_dataset(
         if frames_per_chunk > 0:
             chunk_shape = [0, 0, 0]
             chunk_shape[slicing_dim] = frames_per_chunk
-            DIMS = [0, 1, 2]
-            non_slicing_dims = list(set(DIMS) - set([slicing_dim]))
             for dim in non_slicing_dims:
                 chunk_shape[dim] = global_shape[dim]
             chunk_shape = tuple(chunk_shape)

--- a/httomo/methods.py
+++ b/httomo/methods.py
@@ -136,14 +136,21 @@ def setup_dataset(
 
         # adjust the raw data chunk cache options of the dataset
         # according to the chunk size
-        num_chunks = np.prod(np.asarray(global_shape) / np.asarray(chunk_shape)).astype(
-            int
-        )
-        rdcc_opts = {
-            "rdcc_nbytes": data.dtype.itemsize * np.prod(chunk_shape),
-            "rdcc_w0": 1,
-            "rdcc_nslots": _get_rdcc_nslots(num_chunks),
-        }
+        if chunk_shape is not None:
+            num_chunks = np.prod(
+                np.asarray(global_shape) / np.asarray(chunk_shape)
+            ).astype(int)
+            rdcc_opts = {
+                "rdcc_nbytes": data.dtype.itemsize * np.prod(chunk_shape),
+                "rdcc_w0": 1,
+                "rdcc_nslots": _get_rdcc_nslots(num_chunks),
+            }
+        else:
+            rdcc_opts = {
+                "rdcc_nbytes": None,
+                "rdcc_w0": None,
+                "rdcc_nslots": None,
+            }
 
         # only create if not already present - otherwise return existing dataset
         dataset = file.require_dataset(

--- a/httomo/methods.py
+++ b/httomo/methods.py
@@ -16,8 +16,11 @@ __all__ = ["calculate_stats", "save_intermediate_data"]
 # save a copy of the original guess_chunk if it needs to be restored
 ORIGINAL_GUESS_CHUNK = h5py._hl.filters.guess_chunk
 
-# the bandwidth that saturates the file system (single process)
-# this was estimated after performing some benchmarks
+# The bandwidth that saturates the file system (single process).
+# This was estimated using a heuristic approach after performing some
+# benchmarks on GPFS03 at DLS using a graph of bandwidth vs message
+# size. For more detail, see
+# https://github.com/DiamondLightSource/httomo/pull/537
 SATURATION_BW = 512 * 2**20
 
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -271,7 +271,7 @@ def test_save_intermediate_data_frames_per_chunk(
     if frames_per_chunk > 0:
         assert chunk_shape == tuple(expected_chunk_shape)
     elif frames_per_chunk == -1:
-        # when this is -1, it is decided autmatically and because of the
+        # when this is -1, it is decided automatically and because of the
         # very small frame size, this exceeds the value of the slicing
         # dimension, and the fallback is 1
         assert chunk_shape == (1, *expected_chunk_shape[1:])

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -218,7 +218,7 @@ def test_save_intermediate_data_mpi(tmp_path: Path):
         np.testing.assert_array_equal(file["data_dims"]["detector_x_y"], [10, 20])
 
 
-@pytest.mark.parametrize("frames_per_chunk", [0, 1, 5, 1000])
+@pytest.mark.parametrize("frames_per_chunk", [-1, 0, 1, 5, 1000])
 def test_save_intermediate_data_frames_per_chunk(
     tmp_path: Path,
     frames_per_chunk: int,
@@ -268,8 +268,13 @@ def test_save_intermediate_data_frames_per_chunk(
     with h5py.File(tmp_path / FILE_NAME, "r") as f:
         chunk_shape = f[DATA_PATH].chunks
 
-    if frames_per_chunk != 0:
+    if frames_per_chunk > 0:
         assert chunk_shape == tuple(expected_chunk_shape)
+    elif frames_per_chunk == -1:
+        # when this is -1, it is decided autmatically and because of the
+        # very small frame size, this exceeds the value of the slicing
+        # dimension, and the fallback is 1
+        assert chunk_shape == (1, *expected_chunk_shape[1:])
     else:
         assert chunk_shape is None
 


### PR DESCRIPTION
Fixes #423 

This PR provides an option to determine `frames_per_chunk` from the saturation bandwidth of the file system in DLS when it is passed as `-1`. It results in more frames per chunk so that the writing performance is increased because less chunks are needed. Several values about raw data chunk cache (rdcc) are modified to optimise the I/O performance of the dataset.

I observed around 60-70% speed-up (depending on the number of MPI ranks) when using `--frames-per-chunk -1` over `--frames-per-chunk 1`. The performance gain of setting rdcc is not as significant as the change in chunk size. Feel free to test this with different datasets, YMMV.

## Discussion
One thing worth to discuss is whether the choice of `--frames-per-chunk -1` means 'decide it automatically' is good or not. Potentially it can be something like `--frames-per-chunk 'auto'`. 

Another thing is the default value of `frames_per_chunk`, currently it is `1` and if compression is on, I changed it to `-1` (decide automatically) to maximise performance. Feel free to comment on this as this is somehow inconsistent.

I am not sure how frequent `httomo` is used outside DLS, as the saturation bandwidth is hard-coded to 512 MiB currently. This won't be applicable outside DLS, and I am not sure whether it is better to pass something like `--saturation-bw 512`, or set `frames_per_chunk` to 1 as a fall back, or just use a conservative estimate when outside DLS. 

## Saturation benchmark
This is the benchmark I did few months ago to estimate the saturation bandwidth (on i12, applicable to GPFS03), I use 512 MiB to try to accommodate more chunks although the saturation happens roughly about 64 MiB.

![bw-i12](https://github.com/user-attachments/assets/67f05b52-7652-4e9d-a568-e5a30e6490d7)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation