### PR TITLE
Remove some unnecessary copies during iteration over splitter that's given a file-based dataset source

### DIFF
--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -121,7 +121,7 @@ class TaskRunner:
             unit="block",
             ascii=True,
         )
-        for idx, (block, _) in enumerate(zip(splitter, progress)):
+        for idx, block in enumerate(progress):
             end_source = time.perf_counter_ns()
             if self.monitor is not None:
                 self.monitor.report_source_block(


### PR DESCRIPTION
Fixes #543

With this simple change, profiling the block splitter script mentioned in #543 now shows the same behaviour as not using the tqdm progress bar iterable at all (ie, the loop being defined as `for block in progress` rather than what it was posted in that issue):
![with-tqdm-no-splitter-iterable](https://github.com/user-attachments/assets/e58af5c9-b68d-4421-87e2-b99e7e794267)
 
Furthermore, the original pipeline that was run on `ws582` at DLS which previously was getting a RAM OOM error now runs without issue.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
