### PR TITLE
Fixing docs build

### DIFF
--- a/docs/source/doc-conda-requirements.yml
+++ b/docs/source/doc-conda-requirements.yml
@@ -8,6 +8,7 @@ dependencies:
   - sphinx-book-theme
   - pandoc
   - jinja2
+  - nbsphinx
   - sphinx-design
   - sphinx-copybutton
   - pyyaml

--- a/docs/source/doc-conda-requirements.yml
+++ b/docs/source/doc-conda-requirements.yml
@@ -6,7 +6,6 @@ dependencies:
   - numpy
   - sphinx
   - sphinx-book-theme
-  - nbsphinx
   - pandoc
   - jinja2
   - sphinx-design

--- a/docs/source/doc-conda-requirements.yml
+++ b/docs/source/doc-conda-requirements.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.10,<3.13
   - numpy
-  - sphinx
+  - sphinx>=8.0,<8.2.0
   - sphinx-book-theme
   - pandoc
   - jinja2


### PR DESCRIPTION
For some reason in 8.2.0 `sphinx` version the dependency on `nbsphinx` breaks the build. Until the issue is resolved the solution is to use the older `sphinx` version. The `nbsphinx`  package, however, is required for the build to be successful. 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
