### PR TITLE
enabling cpu framework testing pipeline instead of iris ci

### DIFF
--- a/.github/workflows/run_tests_framework_github.yml
+++ b/.github/workflows/run_tests_framework_github.yml
@@ -1,0 +1,40 @@
+name: HTTomo framework tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  tests-cpu:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Create conda environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: conda/environment-cpu.yml
+          environment-name: httomo
+          post-cleanup: 'all'
+          init-shell: bash
+
+      - name: install httomo and httomo-backends
+        run: |
+          micromamba activate httomo
+          pip install --no-deps httomo-backends
+          pip install .
+          micromamba list
+          
+      - name: Run HTTomo framework tests (CPU)
+        run: |
+          pytest tests/

--- a/conda/environment-cpu.yml
+++ b/conda/environment-cpu.yml
@@ -1,20 +1,24 @@
 name: httomo
 channels:
   - conda-forge
-  - httomo
 dependencies:
-  - conda-forge::tomopy==1.15
-  - httomo::httomolib==2.1
-  - conda-forge::click>=8.1.3
-  - conda-forge::mpi4py>=3.1
-  - conda-forge::h5py=*=*mpi_openmpi*
-  - conda-forge::pyyaml
-  - conda-forge::numpy<=1.25
-  - conda-forge::python
-  - conda-forge::numexpr>=2.8.4
-  - conda-forge::ipython
-  - conda-forge::loguru
-  - conda-forge::graypy
-  - conda-forge::plumbum
-  - conda-forge::tqdm
-  - conda-forge::typing_extensions
+  - scipy
+  - pillow
+  - click
+  - numpy
+  - graypy
+  - h5py=*=*mpi_openmpi*
+  - hdf5plugin
+  - loguru
+  - mpi4py
+  - pyyaml
+  - nvtx
+  - python
+  - plumbum
+  - tqdm
+  - typing_extensions
+  - ipython
+  - pytest
+  - pytest-xdist
+  - pytest-cov
+  - pytest-mock


### PR DESCRIPTION
The main purpose of this PR is to move to purely CPU testing of the HTTomo's framework as GPU is not generally needed for that. 
All GPU tests now flagged differently from the framework (CPU) tests and won't be picked up by Github CI. 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
