### PR TITLE
Simplify temp dir setup/teardown in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 import os
 import sys
 from pathlib import Path
-from shutil import rmtree
 from typing import Any, Callable, Dict, List, TypeAlias, Union, Tuple
 import numpy as np
 from PIL import Image
@@ -97,16 +96,10 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture
-def output_folder():
-    if not os.path.exists("output_dir"):
-        os.mkdir("output_dir/")
-    else:
-        for path in Path("output_dir").iterdir():
-            if path.is_file():
-                path.unlink()
-            elif path.is_dir():
-                rmtree(path)
-    return str(Path("output_dir").resolve())
+def output_folder(tmp_path):
+    tmp_dir = tmp_path / "output_dir"
+    tmp_dir.mkdir()
+    return str(Path(tmp_dir).resolve())
 
 
 @pytest.fixture

--- a/tests/test_pipeline_big.py
+++ b/tests/test_pipeline_big.py
@@ -32,7 +32,7 @@ def test_pipeline_gpu_FBP_diad_k11_38731_in_disk(
 
     subprocess.check_output(cmd)
 
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
 
     #: check the generated reconstruction (hdf5 file)
     h5_files = list(filter(lambda x: ".h5" in x, files))
@@ -85,7 +85,7 @@ def test_pipeline_gpu_FBP_diad_k11_38731_in_memory(
 
     subprocess.check_output(cmd)
 
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
 
     #: check the generated reconstruction (hdf5 file)
     h5_files = list(filter(lambda x: ".h5" in x, files))
@@ -144,7 +144,7 @@ def test_pipeline_gpu_FBP_diad_k11_38730_in_disk(
 
     subprocess.check_output(cmd)
 
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
 
     #: check the generated reconstruction (hdf5 file)
     h5_files = list(filter(lambda x: ".h5" in x, files))
@@ -197,7 +197,7 @@ def test_pipeline_gpu_FBP_diad_k11_38730_in_memory(
 
     subprocess.check_output(cmd)
 
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
 
     #: check the generated reconstruction (hdf5 file)
     h5_files = list(filter(lambda x: ".h5" in x, files))
@@ -297,7 +297,7 @@ def test_pipeline_gpu_FBP_denoising_i13_177906_preview(
 
     subprocess.check_output(cmd)
 
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
 
     #: check the generated reconstruction (hdf5 file)
     h5_files = list(filter(lambda x: ".h5" in x, files))
@@ -378,7 +378,7 @@ def test_pipeline_gpu_360_paganin_FBP_i13_179623_preview(
 
     subprocess.check_output(cmd)
 
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
 
     #: check the generated reconstruction (hdf5 file)
     h5_files = list(filter(lambda x: ".h5" in x, files))
@@ -465,7 +465,7 @@ def test_pipeline_gpu_360_distortion_FBP_i13_179623_preview(
 
     subprocess.check_output(cmd)
 
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
 
     #: check the generated reconstruction (hdf5 file)
     h5_files = list(filter(lambda x: ".h5" in x, files))
@@ -516,11 +516,11 @@ def test_gpu_pipeline_sweep_FBP_i13_177906(
 
     subprocess.check_output(cmd)
 
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
     files_references = get_files(gpu_pipeline_sweep_FBP_i13_177906_tiffs)
 
     # recurse through output_dir and check that all files are there
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
     assert len(files) == 12
 
     #: check the number of the resulting tif files

--- a/tests/test_pipeline_small.py
+++ b/tests/test_pipeline_small.py
@@ -36,7 +36,7 @@ def test_run_pipeline_cpu_gridrec(
     subprocess.check_output(cmd)
 
     # recurse through output_dir and check that all files are there
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
     assert len(files) == 132  # 128 images + yaml, 2 logfiles, intermediate
 
     check_tif(files, 128, (160, 160))
@@ -69,7 +69,7 @@ def test_run_pipeline_gpu_FBP(
     subprocess.check_output(cmd)
 
     # recurse through output_dir and check that all files are there
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
     assert len(files) == 132
 
     check_tif(files, 128, (160, 160))
@@ -132,7 +132,7 @@ def test_run_pipeline_gpu_denoise(
     subprocess.check_output(cmd)
 
     # recurse through output_dir and check that all files are there
-    files = get_files("output_dir/")
+    files = get_files(output_folder)
     assert len(files) == 132
 
     check_tif(files, 128, (160, 160))


### PR DESCRIPTION
Pytest has functionality to provide temporary directories for tests (see https://docs.pytest.org/en/stable/how-to/tmp_path.html), so there's no need to have custom logic to setup and teardown temporary directories in tests.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
