### PR TITLE
Execute intermediate data wrapper in output recon file naming tests

### DIFF
--- a/tests/method_wrappers/test_save_intermediate.py
+++ b/tests/method_wrappers/test_save_intermediate.py
@@ -288,6 +288,7 @@ def test_writes_core_of_blocks_only(
 )
 def test_recon_method_output_filename(
     get_files: Callable,
+    dummy_block: DataSetBlock,
     mocker: MockerFixture,
     tmp_path: Path,
     recon_filename_stem_global_var: Optional[str],
@@ -346,8 +347,9 @@ def test_recon_method_output_filename(
         loader=loader,
         prev_method=prev_method,
     )
-
     assert isinstance(wrp, SaveIntermediateFilesWrapper)
+
+    wrp.execute(dummy_block)
     files = get_files(tmp_path)
     assert len(files) == 1
     assert Path(files[0]).name == expected_filename
@@ -356,6 +358,7 @@ def test_recon_method_output_filename(
 @pytest.mark.parametrize("recon_filename_stem_global_var", [None, "some-recon"])
 def test_non_recon_method_output_filename(
     get_files: Callable,
+    dummy_block: DataSetBlock,
     mocker: MockerFixture,
     tmp_path: Path,
     recon_filename_stem_global_var: Optional[str],
@@ -407,8 +410,9 @@ def test_non_recon_method_output_filename(
         loader=loader,
         prev_method=prev_method,
     )
-
     assert isinstance(wrp, SaveIntermediateFilesWrapper)
+
+    wrp.execute(dummy_block)
     files = get_files(tmp_path)
     assert len(files) == 1
     assert Path(files[0]).name == EXPECTED_FILENAME


### PR DESCRIPTION
Fixes #577

Based on information in [the hdf5 docs on file locks](https://support.hdfgroup.org/documentation/hdf5/latest/_file_lock.html) saying that the locks are not needed when running multiple processes working together (such as when running processes using MPI), I had noted that running the 6 offending tests in `test_save_intermediate_data` under `mpirun -n 1` never produced the error, and chalked it off as some anomaly where those tests needed to be run under MPI to pass locally.

However, since then, I noticed that those offending tests only ever create the hdf5 file for saving, and the `execute()` method on the wrapper object is never called.

This test is parameterised to have 4 of the 6 failing cases: https://github.com/DiamondLightSource/httomo/blob/c0036b9da10410bc52a4b7fddf8f3c4051de7ca6/tests/method_wrappers/test_save_intermediate.py#L340-L353

and this test is parameterised with 2 of the 6 failing cases: https://github.com/DiamondLightSource/httomo/blob/c0036b9da10410bc52a4b7fddf8f3c4051de7ca6/tests/method_wrappers/test_save_intermediate.py#L401-L414

where the absence of `wrp.execute()` should be noted.

The `execute()` method is what actually closes the hdf5 file: https://github.com/DiamondLightSource/httomo/blob/c0036b9da10410bc52a4b7fddf8f3c4051de7ca6/httomo/method_wrappers/save_intermediate.py#L94-L95

This was confirmed to indeed be the issue, where simply running the `execute()` method on the intermediate data wrapper objects makes the hdf5 file locks not appear anymore when running tests locally.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
