### PR TITLE
Use minimum block length as frames-per-chunk value if frames-per-chunk calculation exceeds minimum block length

### DIFF
--- a/httomo/methods.py
+++ b/httomo/methods.py
@@ -54,6 +54,7 @@ def save_intermediate_data(
     slicing_dim: int,
     file: h5py.File,
     frames_per_chunk: int,
+    minimum_block_length: int,
     path: str,
     detector_x: int,
     detector_y: int,
@@ -70,6 +71,7 @@ def save_intermediate_data(
             slicing_dim,
             frames_per_chunk,
             global_shape,
+            minimum_block_length,
             filetype="hdf5",
         )
 
@@ -83,6 +85,7 @@ def setup_dataset(
     slicing_dim: int,
     frames_per_chunk: int,
     global_shape: Tuple[int, int, int],
+    minimum_block_length: int,
     filetype: str,
 ) -> h5py.Dataset:
 
@@ -112,6 +115,17 @@ def setup_dataset(
             )
             log_once(warn_message, logging.DEBUG)
             frames_per_chunk = 1
+
+        if frames_per_chunk > minimum_block_length:
+            warn_message = (
+                f"frames_per_chunk={frames_per_chunk} exceeds length of smallest block "
+                f"within section ({minimum_block_length}), in slicing_dim={slicing_dim} "
+                f"of data with shape {data.shape}. Falling back to {minimum_block_length} "
+                "frames per chunk"
+            )
+            log_once(warn_message, logging.DEBUG)
+            frames_per_chunk = minimum_block_length
+
         if frames_per_chunk > 0:
             chunk_shape = [0, 0, 0]
             chunk_shape[slicing_dim] = frames_per_chunk

--- a/httomo/runner/section.py
+++ b/httomo/runner/section.py
@@ -174,3 +174,13 @@ def determine_section_padding(section: Section) -> Tuple[int, int]:
         if method.padding:
             return method.calculate_padding()
     return (0, 0)
+
+
+def determine_minimum_block_length(
+    chunk_slicing_dim_length: int, max_slices: int
+) -> int:
+    """
+    Determine length of smallest block within chunk along slicing dimension, given max slices.
+    """
+    remainder = chunk_slicing_dim_length % max_slices
+    return max_slices if remainder == 0 else remainder

--- a/tests/runner/test_section.py
+++ b/tests/runner/test_section.py
@@ -3,7 +3,12 @@ import pytest
 from pytest_mock import MockerFixture
 from httomo.runner.output_ref import OutputRef
 from httomo.runner.pipeline import Pipeline
-from httomo.runner.section import determine_section_padding, sectionize, Section
+from httomo.runner.section import (
+    determine_minimum_block_length,
+    determine_section_padding,
+    sectionize,
+    Section,
+)
 from ..testing_utils import make_test_loader, make_test_method
 
 from httomo_backends.methods_database.query import Pattern
@@ -373,3 +378,18 @@ def test_determine_section_padding_one_padding_method_and_other_methods_in_secti
 
     section_padding = determine_section_padding(sections[0])
     assert section_padding == PADDING
+
+
+@pytest.mark.parametrize(
+    "chunk_size_slicing_dim_length, max_slices",
+    [(2560, 640), (2560, 400), (2560, 220), (2560, 100)],
+)
+def test_determine_minimum_block_length(
+    chunk_size_slicing_dim_length: int, max_slices: int
+):
+    remainder = chunk_size_slicing_dim_length % max_slices
+    expected_minimum_block_length = max_slices if remainder == 0 else remainder
+    assert (
+        determine_minimum_block_length(chunk_size_slicing_dim_length, max_slices)
+        == expected_minimum_block_length
+    )


### PR DESCRIPTION
Fixes #566

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
