### PR TITLE
Add MPI abort handler for unhandled exceptions

### DIFF
--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -17,6 +17,7 @@ from httomo.monitors import MONITORS_MAP, make_monitors
 from httomo.runner.pipeline import Pipeline
 from httomo.sweep_runner.param_sweep_runner import ParamSweepRunner
 from httomo.transform_layer import TransformLayer
+from httomo.utils import mpi_abort_excepthook
 from httomo.yaml_checker import validate_yaml_config
 from httomo.runner.task_runner import TaskRunner
 from httomo.ui_layer import UiLayer, PipelineFormat
@@ -213,6 +214,8 @@ def run(
     recon_filename_stem: Optional[str],
 ):
     """Run a pipeline on input data."""
+    sys.excepthook = mpi_abort_excepthook
+
     set_global_constants(
         out_dir,
         intermediate_format,
@@ -254,6 +257,8 @@ def run(
         )
     else:
         execute_sweep_run(pipeline, global_comm)
+
+    sys.excepthook = sys.__excepthook__
 
 
 def _check_yaml(yaml_config: Path, in_data: Path):

--- a/httomo/utils.py
+++ b/httomo/utils.py
@@ -1,6 +1,8 @@
+import sys
 import logging
 from enum import Enum
 from time import perf_counter_ns
+from traceback import format_tb
 from typing import Any, Callable, Dict, List, Literal, Tuple
 
 from loguru import logger
@@ -288,3 +290,10 @@ def make_3d_shape_from_array(array: np.ndarray) -> Tuple[int, int, int]:
     with the right typing type (required to make mypy type checks work)
     """
     return make_3d_shape_from_shape(list(array.shape))
+
+
+def mpi_abort_excepthook(type, value, traceback):
+    log_rank(f" {type.__name__}: {value}", MPI.COMM_WORLD)
+    log_rank("\n".join(format_tb(traceback)), MPI.COMM_WORLD)
+    MPI.COMM_WORLD.Abort()
+    sys.__excepthook__(type, value, traceback)


### PR DESCRIPTION
See DLS internal JIRA tickets such as https://jira.diamond.ac.uk/browse/IMGDA-451 and https://jira.diamond.ac.uk/browse/IMGDA-405.

Instead of the program "hanging" in the case when one or more processes get killed but not all of them and the program needs to be Ctrl-c, such as the following:
```
  File "/dls/science/users/twi18192/httomo/httomo/runner/section.py", line 185, in determine_minimum_block_length
    remainder = chunk_slicing_dim_length % max_slices
    remainder = chunk_slicing_dim_length % max_slices
                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
ZeroDivisionError: integer modulo by zero
                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
ZeroDivisionError: integer modulo by zero
^Csrun: interrupt (one more within 1 sec to abort)
srun: StepId=21243475.2 tasks 0-3: running
^Csrun: interrupt (one more within 1 sec to abort)
srun: StepId=21243475.2 tasks 0-3: running
^Csrun: interrupt (one more within 1 sec to abort)
srun: StepId=21243475.2 tasks 0-3: running
^Csrun: interrupt (one more within 1 sec to abort)
srun: StepId=21243475.2 tasks 0-3: running
^Csrun: interrupt (one more within 1 sec to abort)
srun: StepId=21243475.2 tasks 0-3: running
^Csrun: interrupt (one more within 1 sec to abort)
srun: StepId=21243475.2 tasks 0-3: running
^Csrun: sending Ctrl-C to StepId=21243475.2
srun: forcing job termination
srun: Job step aborted: Waiting up to 32 seconds for job step to finish.
^Csrun: sending Ctrl-C to StepId=21243475.2
slurmstepd: error: *** STEP 21243475.2 ON cs05r-sc-gpu06-04 CANCELLED AT 2025-08-06T11:44:15 ***
srun: job abort in progress
[twi18192@cs04r-sc-vserv-300 httomo (mpi-abort-unhandled-exceptions)]$
```

the program will be such that all MPI processes are killed, and the program doesn't need to be Ctrl-c, such as the following:
```
Section 1 (pattern=sinogram) with the following methods:
    FBP3d_tomobar (httomolibgpu)
    save_intermediate_data (httomo)
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 0.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 1 in communicator MPI_COMM_WORLD
with errorcode 0.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 3 in communicator MPI_COMM_WORLD
with errorcode 0.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
slurmstepd: error: *** STEP 21243475.1 ON cs05r-sc-gpu06-04 CANCELLED AT 2025-08-06T11:40:58 ***
srun: Job step aborted: Waiting up to 32 seconds for job step to finish.
[twi18192@cs04r-sc-vserv-300 httomo (mpi-abort-unhandled-exceptions)]$
```

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
