### PR TITLE
Making a keyword (null) to work for image_key_path in the loader

### DIFF
--- a/httomo/darks_flats.py
+++ b/httomo/darks_flats.py
@@ -88,9 +88,16 @@ def get_darks_flats(
 
     def get_together_or_dummy() -> Tuple[np.ndarray, np.ndarray]:
         with h5py.File(darks_config.file, "r") as f:
-            darks_indices = np.where(f[darks_config.image_key_path][:] == 2)[0]
-            flats_indices = np.where(f[flats_config.image_key_path][:] == 1)[0]
             dataset: h5py.Dataset = f[darks_config.data_path]
+            if darks_config.image_key_path is not None:
+                darks_indices = np.where(f[darks_config.image_key_path][:] == 2)[0]
+            else:
+                darks_indices = []
+            if flats_config.image_key_path is not None:
+                flats_indices = np.where(f[flats_config.image_key_path][:] == 1)[0]
+            else:
+                flats_indices = []
+
             if len(darks_indices) == 0 or darks_config.ignore:
                 # there are no darks in the data file OR we need to ignore them, so we generate a dummy array
                 darks = np.zeros(

--- a/httomo/method_wrappers/rotation.py
+++ b/httomo/method_wrappers/rotation.py
@@ -236,6 +236,10 @@ class RotationWrapper(GenericMethodWrapper):
         self, sino: xp.ndarray, flats: Optional[xp.ndarray], darks: Optional[xp.ndarray]
     ) -> xp.ndarray:
         """cpu/gpu agnostic function for normalising a sinogram slice, all input arrays should be either cupy or numpy."""
+        if getattr(sino, "device", None) is not None:
+            import cupy as xp
+        else:
+            import numpy as xp
         flats1d = (
             1.0
             if (flats is None or flats.size == 0)

--- a/httomo/transform_loader_params.py
+++ b/httomo/transform_loader_params.py
@@ -376,6 +376,8 @@ def parse_config(
         image_key_path = str(Path(tomo_entry_path / IMAGE_KEY_PATH))
     else:
         image_key_path = config.get("image_key_path", None)
+        if image_key_path == "None" or image_key_path == "null":
+            image_key_path = None
 
     if is_angles_auto:
         assert tomo_entry_path is not None

--- a/httomo/transform_loader_params.py
+++ b/httomo/transform_loader_params.py
@@ -376,8 +376,6 @@ def parse_config(
         image_key_path = str(Path(tomo_entry_path / IMAGE_KEY_PATH))
     else:
         image_key_path = config.get("image_key_path", None)
-        if image_key_path == "None" or image_key_path == "null":
-            image_key_path = None
 
     if is_angles_auto:
         assert tomo_entry_path is not None

--- a/httomo/yaml_checker.py
+++ b/httomo/yaml_checker.py
@@ -161,6 +161,8 @@ def check_hdf5_paths_against_loader(conf: PipelineConfig, in_file_path: str) -> 
         key for key in params if "_path" in key and key in non_auto_params
     ]
     for key in non_auto_path_keys:
+        if key == "image_key_path" and params[key] is None:
+            break
         if params[key].strip("/") not in hdf5_members:
             _print_with_colour(
                 f"'{params[key]}' is not a valid path to a dataset in YAML_CONFIG. "


### PR DESCRIPTION
1. Making a keyword (`null`) to work for `image_key_path` in the loader by bypassing a check for a valid path (`params[key].strip("/")`) in yaml checker. 
2. Ensuring that the dummy flats/darks are created for data without d/f and the absence of the key
3. Some corrections about the agnostic `normalize_sino` as there was an ambiguity (cupy/numpy) between the `xp` object inside the function and the data passed to that function  


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
