### PR TITLE
making sweep runs to save 16 bit images instead of 8bit

### DIFF
--- a/httomo/transform_layer.py
+++ b/httomo/transform_layer.py
@@ -142,10 +142,13 @@ class TransformLayer:
                 methods.append(
                     GenericMethodWrapper(
                         self._repo,
-                        "httomolibgpu.misc.rescale",
+                        "httomolib.misc.rescale",
                         "rescale_to_int",
                         comm=self._comm,
                         save_result=False,
+                        perc_range_min=5.0,
+                        perc_range_max=95.0,
+                        bits=16,
                         glob_stats=OutputRef(
                             mapped_output_name="glob_stats",
                             method=m,


### PR DESCRIPTION
Adding rescale to int parameters modifications to sweep runs

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
