### PR TITLE
reducing the preview size for a quicker test run

### DIFF
--- a/tests/test_parallel_pipeline_big.py
+++ b/tests/test_parallel_pipeline_big.py
@@ -398,7 +398,7 @@ def test_parallel_pipe_360deg_distortion_FBP3d_tomobar_i13_179623_preview(
             "neglog",
         ],
         value=[
-            {"detector_y": {"start": 900, "stop": 1200}},
+            {"detector_y": {"start": 900, "stop": 1100}},
             False,
             "mid",
             True,


### PR DESCRIPTION
with larger preview sizes, some tests take a lot of time (reslice is slow), therefore reduce preview here 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
