### PR TITLE
OutputRef cannot be accessed in a method when padding is also enabled

### DIFF
--- a/httomo/method_wrappers/generic.py
+++ b/httomo/method_wrappers/generic.py
@@ -476,7 +476,12 @@ class GenericMethodWrapper(MethodWrapper):
         params = dict()
         for name, value in self.config_params.items():
             if isinstance(value, OutputRef):
-                params[name] = value.value
+                # at this point value.value doesn't exist
+                try:
+                    value_extracted = value.value
+                except:
+                    value_extracted = None
+                params[name] = value_extracted
                 continue
             params[name] = value
         return params


### PR DESCRIPTION
It is a combination when we produce side_output with the centering method and then trying to access that value with  a following method (e.g. reconstruction) that is also does the padding. Test to reproduce the issue is probably needed. 

A possible workaround to avoid accessing the nonexistent value in OutputRef.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
