### PR TITLE
attempt on fixing the padding issue

### DIFF
--- a/httomo/runner/dataset_store_interfaces.py
+++ b/httomo/runner/dataset_store_interfaces.py
@@ -140,7 +140,7 @@ class ReadableDataSetSink(DataSetSink):
 
     @abc.abstractmethod
     def make_reader(
-        self, new_slicing_dim: Optional[Literal[0, 1, 2]] = None
+        self, new_slicing_dim: Optional[Literal[0, 1, 2]] = None, padding: Optional[Tuple[int, int]] = None
     ) -> DataSetSource:
         """Method to make a source from this sink, which will read the data that was written,
         possibly in a new slicing dimension"""

--- a/httomo/runner/task_runner.py
+++ b/httomo/runner/task_runner.py
@@ -184,7 +184,7 @@ class TaskRunner:
             # we have a store-based sink from the last section - use that to determine
             # the source for this one
             assert isinstance(self.sink, ReadableDataSetSink)
-            self.source = self.sink.make_reader(slicing_dim_section)
+            self.source = self.sink.make_reader(slicing_dim_section, determine_section_padding(section))
 
         store_backing = determine_store_backing(
             comm=self.comm,


### PR DESCRIPTION
This is an initial attempt to fix the issue of padding. The change is to ensure that `self.sink.make_reader` gets information about the padding. Previously it wasn't estimating it, assuming it is None for all consequent sessions after the first section (where I think padding works as expected). 
With that change I can confirm that when running httomo serially, the padding does what it should do. 
Running iterative regularised reconstruction when padding is provided as (1,1)
<img width="535" height="158" alt="image" src="https://github.com/user-attachments/assets/64dc4708-f10e-4357-a9c5-e49b338f680f" />
when padding (5,5)
<img width="439" height="114" alt="image" src="https://github.com/user-attachments/assets/25242a64-cdcd-4bdc-a4b7-c4519a9426e2" />

Unfortunately for parallel runs  I get an error, which is probably to the sink when data is written to the disk.
**_2025-10-08 14:24:07.137 | DEBUG    | httomo.utils:log_rank:75 - RANK: [1],  ValueError: Unable to synchronously create dataset (invalid identifier type to function)_**

There is a big data test that currently stalls with this change. 
tests/test_parallel_pipeline_big.py::test_parallel_pipe_FBP3d_tomobar_denoising_i13_177906_preview --full_data_parallel

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
