### PR TITLE
Transform section pattern for some cases of non-auto axis image saver

### DIFF
--- a/httomo/runner/section.py
+++ b/httomo/runner/section.py
@@ -6,6 +6,7 @@ into a section.
 import logging
 from typing import Iterator, List, Optional, Tuple
 
+from httomo.method_wrappers.images import ImagesWrapper
 from httomo.runner.output_ref import OutputRef
 from httomo.runner.pipeline import Pipeline
 from httomo.utils import log_once
@@ -111,6 +112,7 @@ def sectionize(pipeline: Pipeline) -> List[Section]:
     sections[-1].is_last = True
 
     _backpropagate_section_patterns(pipeline, sections)
+    _transform_section_pattern_with_non_auto_axis_image_saver(sections)
     _finalize_patterns(pipeline, sections)
     _set_method_patterns(sections)
 
@@ -157,6 +159,17 @@ def _set_method_patterns(sections: List[Section]):
     for s in sections:
         for m in s:
             m.pattern = s.pattern
+
+
+def _transform_section_pattern_with_non_auto_axis_image_saver(sections: List[Section]):
+    for section in sections:
+        for method in section.methods:
+            if (
+                isinstance(method, ImagesWrapper)
+                and (axis_val := method.config_params.get("axis")) is not None
+                and axis_val != "auto"
+            ):
+                section.pattern = Pattern(axis_val)
 
 
 def determine_section_padding(section: Section) -> Tuple[int, int]:


### PR DESCRIPTION
Fixes https://jira.diamond.ac.uk/browse/IMGDA-606

For cases where the `axis` parameter of the image saver is configured to:
- not be `auto`
- and the given integer value is not the slicing dim represented by the pattern associated with the section the image saver method is in

then the images saved are likely not what is intended.

For example, consider the following sequence of methods:
- normaliser
- stats calculator (produces side output)
- rescaler (depends on side output of global stats)
- image saver (with `axis` set to 1)

The fact that the rescaler requires the side output produced by the stats calculator means that a new section is started after the stats calculator. Thus, where will be two sections made from this sequence of methods.

The normaliser will have the projection pattern, and this means that the first section has the projection pattern (which has slicing dimension 0).

The rescaler has the "all" pattern and so does the image saver. This will ultimately result in the second section having the projection pattern, which means that a chunk will be split into blocks of projections.

However, the image saver's setting of `axis=1` will result in saving images sliced along axis 1 of each of the blocks of projections, which are something like "partial sinograms" within each block of projections. This is unlikely to be what the user intended, and instead what was probably intended was to save the output of the rescaler as "full sinograms". In order to accomplish this, a reslice operation is needed between the first and second section, and this can be achieved by transforming the pattern for the second section from projection to sinogram.

The changes made in this commit perform such a transformation where relevant.

Note that the above example is one specific case, but more generally, this transformation will be applied to a section containing an image saver method if the image saver is configured with an `axis` value that is not `auto` and this value is not the slicing dim represented by the pattern of the image saver's section.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
