### PR TITLE
Issue around absent either darks or flats

### DIFF
--- a/httomo/darks_flats.py
+++ b/httomo/darks_flats.py
@@ -56,7 +56,7 @@ class DarksFlatsFileConfig(NamedTuple):
     """
 
     file: Path
-    data_path: str
+    data_path: Optional[str]
     image_key_path: Optional[str]
     ignore: bool = False
 
@@ -145,8 +145,12 @@ def get_darks_flats(
             ]
 
     if darks_config.file != flats_config.file:
-        darks = get_separate(darks_config)
-        flats = get_separate(flats_config)
+        darks = None
+        flats = None
+        if not darks_config.ignore:
+            darks = get_separate(darks_config)
+        if not flats_config.ignore:
+            flats = get_separate(flats_config)
         return darks, flats  # type: ignore
 
     return get_together_or_dummy()

--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -171,7 +171,7 @@ class DataSetBlock(BaseBlock, BlockIndexing):
 
     def _empty_aux_array(self):
         empty_shape = list(self._data.shape)
-        empty_shape[self.slicing_dim] = 0
+        empty_shape[self.slicing_dim] = 1
         return np.empty_like(self._data, shape=empty_shape)
 
     @property

--- a/httomo/transform_loader_params.py
+++ b/httomo/transform_loader_params.py
@@ -425,22 +425,29 @@ def parse_config(
 
     data_config = DataConfig(in_file=input_file, data_path=str(data_path))
 
-    
     darks_value = config.get("darks", None)
     if darks_value == "ignore" or darks_value is None:
-        darks_config = DarksFlatsFileConfig(file=input_file,data_path=None,image_key_path=None, ignore=True)
+        darks_config = DarksFlatsFileConfig(
+            file=input_file, data_path=None, image_key_path=None, ignore=True
+        )
     else:
         if "image_key_path" not in darks_value:
-            darks_value["image_key_path"] = None        
-        darks_config = parse_darks_flats(data_config, image_key_path, darks_value, ignore=False)
+            darks_value["image_key_path"] = None
+        darks_config = parse_darks_flats(
+            data_config, image_key_path, darks_value, ignore=False
+        )
 
     flats_value = config.get("flats", None)
     if flats_value == "ignore" or flats_value is None:
-        flats_config = DarksFlatsFileConfig(file=input_file,data_path=None,image_key_path=None, ignore=True)
+        flats_config = DarksFlatsFileConfig(
+            file=input_file, data_path=None, image_key_path=None, ignore=True
+        )
     else:
         if "image_key_path" not in flats_value:
             flats_value["image_key_path"] = None
-        flats_config = parse_darks_flats(data_config, image_key_path, flats_value, ignore=False)
+        flats_config = parse_darks_flats(
+            data_config, image_key_path, flats_value, ignore=False
+        )
 
     return (
         data_config,

--- a/httomo/transform_loader_params.py
+++ b/httomo/transform_loader_params.py
@@ -322,8 +322,8 @@ class DarksFlatsParam(TypedDict):
     Darks/flats configuration dict.
     """
 
-    file: str
-    data_path: str
+    file: Path
+    data_path: Optional[str]
     image_key_path: Optional[str]
     ignore: bool
 
@@ -425,26 +425,22 @@ def parse_config(
 
     data_config = DataConfig(in_file=input_file, data_path=str(data_path))
 
+    
     darks_value = config.get("darks", None)
-    ignore_darks = False
-    if darks_value == "ignore":
-        ignore_darks = True  # ignore darks in the data
-        darks_value = None
-    if darks_value is not None and "image_key_path" not in darks_value:
-        darks_value["image_key_path"] = None
-    darks_config = parse_darks_flats(
-        data_config, image_key_path, darks_value, ignore=ignore_darks
-    )
+    if darks_value == "ignore" or darks_value is None:
+        darks_config = DarksFlatsFileConfig(file=input_file,data_path=None,image_key_path=None, ignore=True)
+    else:
+        if "image_key_path" not in darks_value:
+            darks_value["image_key_path"] = None        
+        darks_config = parse_darks_flats(data_config, image_key_path, darks_value, ignore=False)
+
     flats_value = config.get("flats", None)
-    ignore_flats = False
-    if flats_value == "ignore":
-        ignore_flats = True  # ignore flats in the data
-        flats_value = None
-    if flats_value is not None and "image_key_path" not in flats_value:
-        flats_value["image_key_path"] = None
-    flats_config = parse_darks_flats(
-        data_config, image_key_path, flats_value, ignore=ignore_flats
-    )
+    if flats_value == "ignore" or flats_value is None:
+        flats_config = DarksFlatsFileConfig(file=input_file,data_path=None,image_key_path=None, ignore=True)
+    else:
+        if "image_key_path" not in flats_value:
+            flats_value["image_key_path"] = None
+        flats_config = parse_darks_flats(data_config, image_key_path, flats_value, ignore=False)
 
     return (
         data_config,

--- a/tests/runner/test_dataset_block.py
+++ b/tests/runner/test_dataset_block.py
@@ -33,10 +33,10 @@ def test_full_block_for_global_data():
     np.testing.assert_array_equal(data, block.data)
     np.testing.assert_array_equal(angles, block.angles)
     np.testing.assert_array_equal(angles, block.angles_radians)
-    assert block.darks.shape == (0, 10, 10)
-    assert block.dark.shape == (0, 10, 10)
-    assert block.flats.shape == (0, 10, 10)
-    assert block.flat.shape == (0, 10, 10)
+    assert block.darks.shape == (1, 10, 10)
+    assert block.dark.shape == (1, 10, 10)
+    assert block.flats.shape == (1, 10, 10)
+    assert block.flat.shape == (1, 10, 10)
     assert block.darks.dtype == data.dtype
     assert block.flats.dtype == data.dtype
     assert block.dark.dtype == data.dtype


### PR DESCRIPTION
Fixes https://jira.diamond.ac.uk/browse/IMGDA-650

Before fixing the tests it would be great to discuss if this is the acceptable solution. It does, however,  fix the problem mentioned in the issue. 

The problem occurs when flats or darks are used with  `None` or `ignore` flags in the YAML file. The reason for this  is that `parse_config` in `transform_loader_params1` builds the configuration files (DarksFlatsFileConfig) for D or F incorrectly. In that particular case, darks (wanted to be ignored) are created using the original dataset,  basically `darks = data`.  So I changed it in way that  D or F are truly ignored when needed. So most of the keys are None, e.g.,
```
 darks_config = DarksFlatsFileConfig(
            file=input_file, data_path=None, image_key_path=None, ignore=True
        )
```

Another issue was around `empty_shape[self.slicing_dim] = 0` making a zero array which cannot be flattened later in data reducer. So that `np.mean(data, axis=axis, dtype=np.float32, out=reduced_data[0, :, :])` would result in NaNs in the output. And because we do not run data_checker on flats/darks after squashing, it destroys the result of the normalisation.  Making it `empty_shape[self.slicing_dim] = 1` resolves the problem. 


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
