### PR TITLE
fixing rotation phase crosscorrelation issue

### DIFF
--- a/httomo/method_wrappers/rotation.py
+++ b/httomo/method_wrappers/rotation.py
@@ -111,7 +111,7 @@ class RotationWrapper(GenericMethodWrapper):
         res: Optional[Union[tuple, float, np.float32]] = None
         if self.method.__name__ == "find_center_pc":
             # initialising proj1 & proj2
-            if block.global_index[block.slicing_dim] == 0:
+            if block.global_index_unpadded[block.slicing_dim] == 0:
                 self.proj1 = block.data[0, :, :]  # first frame in the whole dataset
                 if self.cupyrun:
                     self.proj1 = xp.asnumpy(self.proj1)


### PR DESCRIPTION
Fixes [ISSUE](https://jira.diamond.ac.uk/browse/IMGDA-675)

As with padding `global_index` can be changed to negative indexing (`remove_outlier` in the pipeline), we need to look at `global_index_unpadded` instead.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
