### PR TITLE
fixing the bug on flattening auxiliary data

### DIFF
--- a/httomo/runner/dataset.py
+++ b/httomo/runner/dataset.py
@@ -171,7 +171,7 @@ class DataSetBlock(BaseBlock, BlockIndexing):
 
     def _empty_aux_array(self):
         empty_shape = list(self._data.shape)
-        empty_shape[self.slicing_dim] = 0
+        empty_shape[self.slicing_dim] = 1
         return np.empty_like(self._data, shape=empty_shape)
 
     @property

--- a/tests/runner/test_dataset_block.py
+++ b/tests/runner/test_dataset_block.py
@@ -33,10 +33,10 @@ def test_full_block_for_global_data():
     np.testing.assert_array_equal(data, block.data)
     np.testing.assert_array_equal(angles, block.angles)
     np.testing.assert_array_equal(angles, block.angles_radians)
-    assert block.darks.shape == (0, 10, 10)
-    assert block.dark.shape == (0, 10, 10)
-    assert block.flats.shape == (0, 10, 10)
-    assert block.flat.shape == (0, 10, 10)
+    assert block.darks.shape == (1, 10, 10)
+    assert block.dark.shape == (1, 10, 10)
+    assert block.flats.shape == (1, 10, 10)
+    assert block.flat.shape == (1, 10, 10)
     assert block.darks.dtype == data.dtype
     assert block.flats.dtype == data.dtype
     assert block.dark.dtype == data.dtype


### PR DESCRIPTION
Fixes the issue of aux data flattening in this [PR](https://github.com/DiamondLightSource/httomo/pull/656)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added the `user-release-note` label in order to include this PR in the "Notable
Changes for Users" section in release notes
