### PR TITLE
fixing invalid literal for int() with base 10 error in cli.py

### DIFF
--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -352,7 +352,7 @@ def transform_limit_str_to_bytes(limit_str: str):
         elif limit_upper.endswith("G"):
             return int(float(limit_str[:-1]) * 1024**3)
         else:
-            return int(limit_str)
+            return int(float(limit_str))
     except ValueError:
         raise ValueError(f"invalid memory limit string {limit_str}")
 


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/dls_sw/apps/httomo/latest/build/httomo/cli.py", line 355, in transform_limit_str_to_bytes
    return int(limit_str)
           ^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '44038400000.0'
```

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added the `user-release-note` label in order to include this PR in the "Notable
Changes for Users" section in release notes
