### PR TITLE
Adding a capability of changing the bit depth of saved tiffs in sweep run

### DIFF
--- a/httomo/cli.py
+++ b/httomo/cli.py
@@ -179,6 +179,12 @@ def check(pipeline: Union[Path, str], in_data_file: Optional[Path] = None):
     help="Save intermediate images (snapshots) from some methods in the pipeline.",
 )
 @click.option(
+    "--bits_sweep_images",
+    type=click.INT,
+    default=32,
+    help="Change the bit depth of saved tiff images in the sweep run from default 32 bit to 16 or 8 bit tiffs.",
+)
+@click.option(
     "--monitor",
     type=click.STRING,
     multiple=True,
@@ -257,6 +263,7 @@ def run(
     output_folder_name: Optional[Path],
     gpu_id: int,
     save_all: bool,
+    bits_sweep_images: int,
     reslice_dir: Union[Path, None],
     max_cpu_slices: int,
     max_memory: str,
@@ -320,6 +327,7 @@ def run(
             else pipeline
         ),
         save_all,
+        bits_sweep_images,
         method_wrapper_comm,
         format_enum,
     )
@@ -491,6 +499,7 @@ def generate_pipeline(
     in_data_file: Path,
     pipeline: Union[Path, str],
     save_all: bool,
+    bits_sweep_images: int,
     method_wrapper_comm: MPI.Comm,
     pipeline_format: PipelineFormat,
 ) -> Pipeline:
@@ -504,7 +513,9 @@ def generate_pipeline(
     pipeline_object = init_UiLayer.build_pipeline()
 
     # perform transformations on pipeline
-    tr = TransformLayer(comm=method_wrapper_comm, save_all=save_all)
+    tr = TransformLayer(
+        comm=method_wrapper_comm, save_all=save_all, bits_sweep_images=bits_sweep_images
+    )
     pipeline_object = tr.transform(pipeline_object)
 
     return pipeline_object

--- a/httomo/transform_layer.py
+++ b/httomo/transform_layer.py
@@ -28,10 +28,12 @@ class TransformLayer:
         comm: MPI.Comm,
         repo=MethodDatabaseRepository(),
         save_all=False,
+        bits_sweep_images=32,
         out_dir: Optional[os.PathLike] = None,
     ):
         self._repo = repo
         self._save_all = save_all
+        self._bits_sweep_images = bits_sweep_images
         self._comm = comm
         self._out_dir = out_dir if out_dir is not None else httomo.globals.run_out_dir
 
@@ -162,6 +164,7 @@ class TransformLayer:
                         task_id=f"saveimage_sweep_{m.task_id}",
                         subfolder_name="images_sweep_" + str(m.method_name),
                         axis=1,
+                        bit_depth=self._bits_sweep_images,
                     ),
                 )
                 sweep_before = True


### PR DESCRIPTION
When running HTTomo sweep run one can change the bit depth of auto saved tiffs by providing an extra flag to the runner:
`--bits_sweep_images 16 ` for 16-bit tiffs or `--bits_sweep_images 8` for 8 bit ones. And by default thy are saved as 32-bit tiffs if the flag is not provided.

Fixes [ISSUE](https://jira.diamond.ac.uk/browse/IMGDA-890)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added the `user-release-note` label in order to include this PR in the "Notable
Changes for Users" section in release notes
