### PR TITLE
adding the shortcut key for the same input in d/f of the loader

### DIFF
--- a/docs/source/reference/loaders.rst
+++ b/docs/source/reference/loaders.rst
@@ -182,7 +182,26 @@ in the older scan should be ignored. In this instance, we need to provide a para
           file: path/to/new/file.nxs
           data_path: /entry1/tomo_entry/data/data
           image_key_path: /entry1/tomo_entry/instrument/detector/image_key 
-        
+
+If darks and/or flats are in the same dataset as the input dataset, one can use the :code:`input_data` shortcut for :code:`file` fields. For instance,
+in the situation when darks and flats are the part of the same input dataset, but there are no keys: 
+
+.. code-block:: yaml
+   :emphasize-lines: 7,11
+
+
+    - method: standard_tomo
+      module_path: httomo.data.hdf.loaders
+      parameters:
+        darks:
+          file: input_data
+          data_path: /exchange/darks
+          image_key_path: null
+        flats:
+          file: input_data
+          data_path: /exchange/flats
+          image_key_path: null 
+
 Data without darks/flats
 ++++++++++++++++++++++++
 

--- a/httomo/darks_flats.py
+++ b/httomo/darks_flats.py
@@ -5,7 +5,7 @@ loaders.
 
 from enum import Enum
 from pathlib import Path
-from typing import NamedTuple, Optional, Tuple
+from typing import NamedTuple, Optional, Tuple, Union
 
 import h5py
 import numpy as np
@@ -72,7 +72,7 @@ class DarksFlatsFileConfig(NamedTuple):
     with the other types of data correction or reconstruction avoiding normalisation to d/f.
     """
 
-    file: Path
+    file: Union[Path, str]
     data_path: str
     image_key_path: Optional[str]
 

--- a/httomo/transform_loader_params.py
+++ b/httomo/transform_loader_params.py
@@ -348,6 +348,8 @@ def parse_darks_flats(
     pipeline file, into an internal darks/flats configuration type that loaders can use.
     """
     in_file = config["file"] if config is not None else data_config.in_file
+    if in_file == "input_data":
+        in_file = data_config.in_file
     if isinstance(in_file, str):
         in_file = Path(in_file)
     data_path = config["data_path"] if config is not None else data_config.data_path

--- a/tests/test_transform_loader_params.py
+++ b/tests/test_transform_loader_params.py
@@ -475,11 +475,26 @@ def test_parse_data():
                 image_key_path="/path/to/keys/data_two",
             ),
         ),
+        (
+            DataConfig(Path("/some/path/to/data.nxs"), "/entry1/tomo_entry/data/data"),
+            "/path/to/keys/data_one",
+            {
+                "file": "input_data",
+                "data_path": "/exchange/data",
+                "image_key_path": "/path/to/keys/data_two",
+            },
+            DarksFlatsFileConfig(
+                file=Path("/some/path/to/data.nxs"),
+                data_path="/exchange/data",
+                image_key_path="/path/to/keys/data_two",
+            ),
+        ),
     ],
     ids=[
         "darks/flats-in-input-file",
         "darks/flats-in-separate-file",
         "darks/flats-in-separate-file-with-image-key",
+        "darks/flats-in-same-file-with-different-data-path-shortcut",
     ],
 )
 def test_parse_darks_flats_(


### PR DESCRIPTION
Fixes [issue](https://jira.diamond.ac.uk/browse/IMGDA-970)

If darks or/and flats are the part of the **same** input dataset then one can use `input_data` shortcut/keyword instead of providing the full path to the data, e.g.,

<img width="717" height="314" alt="image" src="https://github.com/user-attachments/assets/86216a87-5ab8-465b-9e37-1db73e4b07c4" />


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [x] I have added the `user-release-note` label in order to include this PR in the "Notable
Changes for Users" section in release notes
