### PR TITLE
Fixes the early report on finished pipeline from sweep

### DIFF
--- a/httomo/sweep_runner/param_sweep_runner.py
+++ b/httomo/sweep_runner/param_sweep_runner.py
@@ -261,6 +261,7 @@ class ParamSweepRunner:
             writer.write_sweep_result(block)
 
         log_once("    Finished parameter sweep")
+        
 
         reader = ParamSweepReader(writer)
         self._block = reader.read_sweep_results()
@@ -273,6 +274,9 @@ class ParamSweepRunner:
             self.prepare()
             self.execute_before_sweep()
             self.execute_sweep()
+            log_once("Stand by until all processes are finished (some can take longer).")
+            comm = MPI.COMM_WORLD
+            comm.Barrier()
             self.execute_after_sweep()
         log_once(f"Pipeline finished. Took {t.elapsed:.3f}s")
 

--- a/httomo/sweep_runner/param_sweep_runner.py
+++ b/httomo/sweep_runner/param_sweep_runner.py
@@ -261,7 +261,6 @@ class ParamSweepRunner:
             writer.write_sweep_result(block)
 
         log_once("    Finished parameter sweep")
-        
 
         reader = ParamSweepReader(writer)
         self._block = reader.read_sweep_results()
@@ -274,7 +273,9 @@ class ParamSweepRunner:
             self.prepare()
             self.execute_before_sweep()
             self.execute_sweep()
-            log_once("Stand by until all processes are finished (some can take longer).")
+            log_once(
+                "Stand by until all processes are finished (some can take longer)."
+            )
             comm = MPI.COMM_WORLD
             comm.Barrier()
             self.execute_after_sweep()


### PR DESCRIPTION
Fixes [issue](https://jira.diamond.ac.uk/browse/IMGDA-944)
"_When sweeping over a parameter where different values have an effect on the total processing time (for example: number of iterations in an iterative reconstruction algorithm), the first rank (25% of the total number of iterations on a 4-GPU taks) completes first and HTTomo reports "Job completed" and prints the total time taken. However, iterations on other GPUs can take considerably longer (in some cases, as obseved, up to half an hour longer) to actually return with some data. This is misleading for the end user, as the only indication that the job is still running is that it is present on the HPC queue._"

Fixed with adding a barrier and an additional message. 
For instance:
```
Running SIRT3d_tomobar (httomolibgpu)
    Beginning parameter sweep
    Parameter name: iterations
    Total number of values across all processes: 7
    Values executed in this process: 4
      0%|          | 0/4 [00:00<?, ?value/s, iterations=1]
     25%|##5       | 1/4 [00:02<00:07,  2.63s/value, iterations=4]
     50%|#####     | 2/4 [00:08<00:09,  4.61s/value, iterations=7]
     75%|#######5  | 3/4 [00:18<00:06,  6.86s/value, iterations=10]
    Finished parameter sweep
Stand by until all processes are finished (some can take longer).
Running save_to_images (httomolib)
Pipeline finished. Took 66.391s

```
## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [x] I have added the `user-release-note` label in order to include this PR in the "Notable
Changes for Users" section in release notes
